### PR TITLE
teoSim updated from controlboard to controlboardwrapper2

### DIFF
--- a/src/libraries/TeoYarp/ravepart/IEncoderImpl.cpp
+++ b/src/libraries/TeoYarp/ravepart/IEncoderImpl.cpp
@@ -81,3 +81,24 @@ bool teo::RavePart::getEncoderAccelerations(double *accs) {
 
 // -----------------------------------------------------------------------------
 
+bool teo::RavePart::getEncodersTimed(double *encs, double *time) {
+    //CD_INFO("\n");  //-- Way too verbose
+
+    bool ok = true;
+    for(unsigned int i=0; i < axes; i++)
+        ok &= getEncoderTimed(i,&(encs[i]),&(time[i]));
+    return ok;
+}
+
+// -----------------------------------------------------------------------------
+
+bool teo::RavePart::getEncoderTimed(int j, double *encs, double *time) {
+    //CD_INFO("(%d)\n",j);  //-- Way too verbose
+
+    getEncoder(j, encs);
+    *time = yarp::os::Time::now();
+
+    return true;
+}
+
+// -----------------------------------------------------------------------------

--- a/src/libraries/TeoYarp/ravepart/ITorqueImpl.cpp
+++ b/src/libraries/TeoYarp/ravepart/ITorqueImpl.cpp
@@ -6,7 +6,7 @@
 
 
 bool teo::RavePart::setTorqueMode() {
-    CD_INFO("setPositionMode()\n");
+    CD_INFO("setTorqueMode()\n");
     return true;
 }
 
@@ -57,7 +57,8 @@ bool teo::RavePart::setTorquePid(int j, const Pid &pid) {
 // -----------------------------------------------------------------------------
 
 bool teo::RavePart::getTorque(int j, double *t) {
-    CD_INFO("joint: %d.\n",j);
+    //CD_INFO("joint: %d.\n",j);  //-- Way too verbose
+    *t = 0;
     return true;
 }
 

--- a/src/libraries/TeoYarp/ravepart/RavePart.hpp
+++ b/src/libraries/TeoYarp/ravepart/RavePart.hpp
@@ -58,7 +58,7 @@ namespace teo
  * @brief The RavePart class implements the YARP_dev IPositionControl, IVelocityControl, IEncoders, etc.
  * interface class member functions.
  */
-class RavePart : public DeviceDriver, public IPositionControl, public IVelocityControl, public IEncoders,
+class RavePart : public DeviceDriver, public IPositionControl, public IVelocityControl, public IEncodersTimed,
                  public IControlLimits, public IControlMode, public ITorqueControl, public RateThread {
     public:
 
@@ -190,7 +190,7 @@ class RavePart : public DeviceDriver, public IPositionControl, public IVelocityC
          */
         virtual bool stop();
 
-    //  ---------- IEncoder Declarations. Implementation in IEncoderImpl.cpp ----------
+    //  ---------- IEncodersTimed Declarations. Implementation in IEncoderImpl.cpp ----------
 
         /**
          * Reset encoder, single joint. Set the encoder value to zero
@@ -263,6 +263,23 @@ class RavePart : public DeviceDriver, public IPositionControl, public IVelocityC
          * @return true if all goes well, false if anything bad happens.
          */
         virtual bool getEncoderAccelerations(double *accs);
+
+        /**
+        * Read the instantaneous acceleration of all axes.
+        * \param encs pointer to the array that will contain the output
+        * \param time pointer to the array that will contain individual timestamps
+        * \return true if all goes well, false if anything bad happens.
+        */
+       virtual bool getEncodersTimed(double *encs, double *time);
+
+       /**
+       * Read the instantaneous acceleration of all axes.
+       * \param j axis index
+       * \param encs encoder value (pointer to)
+       * \param time corresponding timestamp (pointer to)
+       * \return true if all goes well, false if anything bad happens.
+       */
+       virtual bool getEncoderTimed(int j, double *encs, double *time);
 
     //  --------- IVelocityControl Declarations. Implementation in IVelocityImpl.cpp ---------
 

--- a/src/programs/teoGravityCompensator/TeoGravityCompensator.cpp
+++ b/src/programs/teoGravityCompensator/TeoGravityCompensator.cpp
@@ -36,13 +36,13 @@ bool teo::TeoGravityCompensator::configure(yarp::os::ResourceFinder &rf) {
     }
 
     //-- full right arm device (remote) --
-    //yarp::os::Property robotOptionsRA;
-    //robotOptionsRA.put("device","remote_controlboard");
-    //robotOptionsRA.put("local","/teoGravityCompensator/rightArm");
-    //robotOptionsRA.put("remote","/controlboard");
+    yarp::os::Property robotOptionsRA;
+    robotOptionsRA.put("device","remote_controlboard");
+    robotOptionsRA.put("local","/teoGravityCompensator/rightArm");
+    robotOptionsRA.put("remote","/teoSim/rightArm");
 
     //-- id22 left arm device (local) --
-    yarp::os::Property robotOptionsRA;
+    /*yarp::os::Property robotOptionsRA;
     robotOptionsRA.put("device","bodybot");
     robotOptionsRA.put("mode","torque");
     robotOptionsRA.put("canDevice","/dev/can1");
@@ -53,7 +53,7 @@ bool teo::TeoGravityCompensator::configure(yarp::os::ResourceFinder &rf) {
     robotOptionsRA.put("ks",0.0706);
     robotOptionsRA.put("refAccelerations",0.575437);
     robotOptionsRA.put("refSpeeds",737.2798);
-    robotOptionsRA.put("trs",160);
+    robotOptionsRA.put("trs",160);*/
 
     robotDeviceRA.open(robotOptionsRA);
 

--- a/src/programs/teoSim/ManipulatorWrapper.cpp
+++ b/src/programs/teoSim/ManipulatorWrapper.cpp
@@ -62,7 +62,7 @@ void teo::ManipulatorWrapper::push_back_tr(double robotJointTr) {
 bool teo::ManipulatorWrapper::start() {
     vectorOfJointPos.resize( this->vectorOfJointIdx.size() );
     Property options;
-    options.put("device","controlboard");  //
+    options.put("device","controlboardwrapper2");  //
     options.put("subdevice","ravepart");  // ravepart provides more interfaces than test_motor
     options.put("axes", (int)this->vectorOfJointIdx.size() );
     options.put("name", this->manipulatorWrapperName );


### PR DESCRIPTION
Tested with teoGravityCompensator as controlboardwrapper2 was required to enable remote torque references.
