### PR TITLE
Implement yarp::dev::IControlLimits2 in teo::FakeControlboardOR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 tags
 CMakeLists.txt.user
 /build*/
+/.cproject
+/.project

--- a/libraries/TeoYarp/FakeControlboardOR/CMakeLists.txt
+++ b/libraries/TeoYarp/FakeControlboardOR/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 
 LINK_DIRECTORIES(${TEO_LINK_DIRS})
 
-YARP_ADD_PLUGIN(FakeControlboardOR FakeControlboardOR.hpp DeviceDriverImpl.cpp IControlLimitsImpl.cpp IControlModeImpl.cpp IEncodersImpl.cpp IEncodersTimedImpl.cpp IPositionImpl.cpp IPosition2Impl.cpp IVelocityImpl.cpp IVelocity2Impl.cpp ITorqueImpl.cpp SharedArea.cpp RateThreadImpl.cpp)
+YARP_ADD_PLUGIN(FakeControlboardOR FakeControlboardOR.hpp DeviceDriverImpl.cpp IControlLimitsImpl.cpp IControlLimits2Impl.cpp IControlModeImpl.cpp IEncodersImpl.cpp IEncodersTimedImpl.cpp IPositionImpl.cpp IPosition2Impl.cpp IVelocityImpl.cpp IVelocity2Impl.cpp ITorqueImpl.cpp SharedArea.cpp RateThreadImpl.cpp)
 set_target_properties(${KEYWORD} PROPERTIES COMPILE_FLAGS "${OpenRAVE_CXXFLAGS}")
 set_target_properties(${KEYWORD} PROPERTIES LINK_FLAGS "${OpenRAVE_LINK_FLAGS}")
 TARGET_LINK_LIBRARIES(FakeControlboardOR ${OpenRAVE_LIBRARIES} ${OpenRAVE_CORE_LIBRARIES} ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${YARP_LIBRARIES})

--- a/libraries/TeoYarp/FakeControlboardOR/FakeControlboardOR.hpp
+++ b/libraries/TeoYarp/FakeControlboardOR/FakeControlboardOR.hpp
@@ -6,6 +6,7 @@
 #include <yarp/os/all.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/IControlLimits2.h>
 #include <yarp/dev/Drivers.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/sig/all.h>
@@ -62,7 +63,7 @@ namespace teo
 // Note: IPositionControl2 inherits from IPositionControl
 // Note: IVelocityControl2 inherits from IVelocityControl
 class FakeControlboardOR : public yarp::dev::DeviceDriver, public yarp::dev::IPositionControl2, public yarp::dev::IVelocityControl2, public yarp::dev::IEncodersTimed,
-                 public yarp::dev::IControlLimits, public yarp::dev::IControlMode, public yarp::dev::ITorqueControl, public yarp::os::RateThread {
+                 public yarp::dev::IControlLimits2, public yarp::dev::IControlMode, public yarp::dev::ITorqueControl, public yarp::os::RateThread {
     public:
 
         // Set the Thread Rate in the class constructor
@@ -486,6 +487,27 @@ class FakeControlboardOR : public yarp::dev::DeviceDriver, public yarp::dev::IPo
          * @return true if everything goes fine, false otherwise.
          */
         virtual bool getLimits(int axis, double *min, double *max);
+
+    //  --------- IControlLimits2 Declarations. Implementation in IControlLimits2Impl.cpp ---------
+
+        /**
+         * Set the software speed limits for a particular axis, the behavior of the
+         * control card when these limits are exceeded, depends on the implementation.
+         * @param axis joint number
+         * @param min the value of the lower limit
+         * @param max the value of the upper limit
+         * @return true or false on success or failure
+         */
+        virtual bool setVelLimits(int axis, double min, double max);
+
+        /**
+         * Get the software speed limits for a particular axis.
+         * @param axis joint number
+         * @param min pointer to store the value of the lower limit
+         * @param max pointer to store the value of the upper limit
+         * @return true if everything goes fine, false otherwise.
+         */
+        virtual bool getVelLimits(int axis, double *min, double *max);
 
     //  --------- IControlMode Declarations. Implementation in IControlModeImpl.cpp ---------
 

--- a/libraries/TeoYarp/FakeControlboardOR/IControlLimits2Impl.cpp
+++ b/libraries/TeoYarp/FakeControlboardOR/IControlLimits2Impl.cpp
@@ -1,0 +1,23 @@
+// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+#include "FakeControlboardOR.hpp"
+
+// ------------------- IControlLimits2 Related ------------------------------------
+
+bool teo::FakeControlboardOR::setVelLimits(int axis, double min, double max) {
+    CD_DEBUG("\n");
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool teo::FakeControlboardOR::getVelLimits(int axis, double *min, double *max) {
+    CD_DEBUG("\n");
+    // yarpmotorgui's defaults (partitem.cpp)
+    *min = 0;
+    *max = 100;
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+


### PR DESCRIPTION
The aim of these changes is to pass position limit values to yarpmotorgui from teoSim. ControlBoardWrapper enforces usage of IControlLimits2 even if its methods are never called to adjust the position slider's limits.

* https://github.com/robotology/yarp/blob/bbea462/src/libYARP_dev/src/modules/ControlBoardWrapper/ControlBoardWrapper.cpp#L3593
* https://github.com/robotology/yarp/blob/bbea462/src/libYARP_dev/src/modules/ControlBoardWrapper/SubDevice.h#L90

Related to roboticslab-uc3m/teo-body#47. Tested for both `yarpmotorgui` (Qt) and `yarpmotorgui-gtk` commands.