### PR TITLE
Allow different angle representations for LineTrajectory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   #-- (For testBasicCartesianControl) Install FakeControlboard currently at https://github.com/roboticslab-uc3m/openrave-yarp-plugins
   - git clone https://github.com/roboticslab-uc3m/openrave-yarp-plugins
   - cd openrave-yarp-plugins
-  - git checkout 479b52dcebf10eab1b75f9f2afe05d544f81d095
+  - git checkout 9f147182b4aaf984170f4ee9a42f8da2a1b44eb1
   - mkdir build && cd build
   - cmake .. -DENABLE_OpenraveYarpControlboard=OFF -DENABLE_OpenraveYarpPaintSquares=OFF -DENABLE_YarpOpenraveControlboard=OFF -DENABLE_YarpOpenraveControlboardCollision=OFF -DENABLE_teoSim=OFF
   - make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,8 @@ if(ENABLE_coverage)
 endif(ENABLE_coverage)
 
 # Bootstrap YCM
+# https://github.com/robotology/ycm/issues/118
+set(YCM_TAG v0.2.2)
 include(YCMBootstrap)
 
 # Superbuild phase - include color-debug

--- a/libraries/TeoYarp/BasicCartesianControl/DeviceDriverImpl.cpp
+++ b/libraries/TeoYarp/BasicCartesianControl/DeviceDriverImpl.cpp
@@ -87,6 +87,19 @@ bool roboticslab::BasicCartesianControl::open(yarp::os::Searchable& config) {
         iCartesianSolver->setLimits(qMin,qMax);
     }
 
+    // Somewhat dirty hack; we cannot rely on polymorphism yet, thus 'trayectory'
+    // is a LineTrajectory object initialized here again in case the default angle
+    // representation differs from the one used by TEO.
+    yarp::os::Value angleReprValue = config.find("angleRepr");
+    if( !angleReprValue.isNull() )
+    {
+        std::string angleRepr = angleReprValue.asString();
+        if( angleRepr != "axisAngle" )
+        {
+            trajectory = LineTrajectory(angleRepr);
+        }
+    }
+
     return this->start();
 }
 

--- a/libraries/TrajectoryLib/LineTrajectory.cpp
+++ b/libraries/TrajectoryLib/LineTrajectory.cpp
@@ -4,11 +4,11 @@
 
 // -----------------------------------------------------------------------------
 
-roboticslab::LineTrajectory::LineTrajectory() : KdlVectorConverter("axisAngle")
-{
-    _orient = 0;
-    currentTrajectory = 0;
-}
+roboticslab::LineTrajectory::LineTrajectory(const std::string & angleRepr)
+    : KdlVectorConverter(angleRepr),
+      currentTrajectory(0),
+      _orient(0)
+{}
 
 // -----------------------------------------------------------------------------
 

--- a/libraries/TrajectoryLib/LineTrajectory.hpp
+++ b/libraries/TrajectoryLib/LineTrajectory.hpp
@@ -3,6 +3,8 @@
 #ifndef __LINE_TRAJECTORY_HPP__
 #define __LINE_TRAJECTORY_HPP__
 
+#include <string>
+
 #include <kdl/path_line.hpp>
 #include <kdl/rotational_interpolation_sa.hpp>
 #include <kdl/velocityprofile_rect.hpp>
@@ -37,7 +39,7 @@ class LineTrajectory : public Trajectory, public KdlVectorConverter
 {
 public:
 
-    LineTrajectory();
+    LineTrajectory(const std::string & angleRepr = "axisAngle");
 
     /** Cartesian position of the trajectory at movementTime */
     virtual bool getX(const double movementTime, std::vector<double>& x);

--- a/libraries/TrajectoryLib/Trajectory.hpp
+++ b/libraries/TrajectoryLib/Trajectory.hpp
@@ -30,6 +30,8 @@ public:
     /** Cartesian velocity of the trajectory at movementTime */
     virtual bool getXdot(const double movementTime, std::vector<double>& xdot) = 0;
 
+    /** Destructor */
+    virtual ~Trajectory() {}
 };
 
 }  // namespace roboticslab


### PR DESCRIPTION
`BasicCartesianControl` fails in controlling ASIBOT because of a mismatch between angle representations: `LineTrajectory` is forced to initialize with *axisAngle* while ASIBOT solvers cope better with *eulerYZ*. As a result, `LineTrajectory::getX` fills a 7-element vector in the [control loop](https://github.com/roboticslab-uc3m/kinematics-dynamics/blob/84d36fd446d7a2d1efc7ef029fa932fafafb0197/libraries/TeoYarp/BasicCartesianControl/RateThreadImpl.cpp#L31) (translation[3] + axis[3] + angle), but this choice is completely opaque to the cartesian solver [a few lines further down](https://github.com/roboticslab-uc3m/kinematics-dynamics/blob/84d36fd446d7a2d1efc7ef029fa932fafafb0197/libraries/TeoYarp/BasicCartesianControl/RateThreadImpl.cpp#L36) and actually breaks things.

This patch makes `BasicCartesianControl` aware of the preferred angle representation, that is, it's no longer bound solely to the solver device. Rather than that, I pulled it one level up so that the cartesian controller is now responsible of passing the same value to both the solver and the (line) trajectory generator. However, I'm convinced this could need a deeper re-think (maybe a new `ICartesianSolver` method for retrieving the angle repr currently in use?). Please share your opinions on this matter.

PS GitHub complains about merge conflicts for some reason - I can still perform an usual merge from console line. Once/If approved, I'll merge the changes "by hand".