### PR TITLE
Stream forward kinematics data and fetch it in the client device

### DIFF
--- a/libraries/YarpPlugins/AsibotSolver/AsibotConfiguration.hpp
+++ b/libraries/YarpPlugins/AsibotSolver/AsibotConfiguration.hpp
@@ -151,6 +151,57 @@ private:
     std::vector<double> getDiffs(JointsIn qGuess, const Pose & pose);
 };
 
+/**
+ * @ingroup AsibotSolver
+ * @brief Base factory class for AsibotConfiguration.
+ *
+ * Acts as the base class in the <a href="https://stackoverflow.com/a/1741424">
+ * abstract factory pattern</a>, encapsulates individual factories.
+ */
+class AsibotConfigurationFactory
+{
+public:
+    /**
+     * @brief Creates an instance of the concrete class.
+     * @return A pointer to the base class of the inheritance tree.
+     */
+    virtual AsibotConfiguration * create() const = 0;
+    virtual ~AsibotConfigurationFactory() {}
+
+protected:
+    AsibotConfigurationFactory();
+};
+
+/**
+ * @ingroup AsibotSolver
+ * @brief Implementation factory class for AsibotConfigurationLeastOverallAngularDisplacement.
+ *
+ * Implements AsibotConfigurationFactory::create.
+ */
+class AsibotConfigurationLeastOverallAngularDisplacementFactory : public AsibotConfigurationFactory
+{
+public:
+
+    /**
+     * @brief Constructor
+     * @param qMin vector of minimum joint limits [deg]
+     * @param qMax vector of maximum joint limits [deg]
+     */
+    AsibotConfigurationLeastOverallAngularDisplacementFactory(AsibotConfiguration::JointsIn qMin, AsibotConfiguration::JointsIn qMax)
+        : _qMin(qMin), _qMax(qMax)
+    {}
+
+    virtual AsibotConfiguration * create() const
+    {
+        return new AsibotConfigurationLeastOverallAngularDisplacement(_qMin, _qMax);
+    }
+
+private:
+
+    AsibotConfiguration::JointsIn _qMin;
+    AsibotConfiguration::JointsIn _qMax;
+};
+
 }  // namespace roboticslab
 
 #endif  // __ASIBOT_CONFIGURATION_HPP__

--- a/libraries/YarpPlugins/AsibotSolver/AsibotConfiguration.hpp
+++ b/libraries/YarpPlugins/AsibotSolver/AsibotConfiguration.hpp
@@ -169,7 +169,7 @@ public:
     virtual ~AsibotConfigurationFactory() {}
 
 protected:
-    AsibotConfigurationFactory();
+    AsibotConfigurationFactory() {}
 };
 
 /**

--- a/libraries/YarpPlugins/AsibotSolver/AsibotConfiguration.hpp
+++ b/libraries/YarpPlugins/AsibotSolver/AsibotConfiguration.hpp
@@ -161,6 +161,7 @@ private:
 class AsibotConfigurationFactory
 {
 public:
+
     /**
      * @brief Creates an instance of the concrete class.
      * @return A pointer to the base class of the inheritance tree.
@@ -169,7 +170,17 @@ public:
     virtual ~AsibotConfigurationFactory() {}
 
 protected:
-    AsibotConfigurationFactory() {}
+
+    /**
+     * @brief Constructor
+     * @param qMin vector of minimum joint limits [deg]
+     * @param qMax vector of maximum joint limits [deg]
+     */
+    AsibotConfigurationFactory(AsibotConfiguration::JointsIn qMin, AsibotConfiguration::JointsIn qMax)
+        : _qMin(qMin), _qMax(qMax)
+    {}
+
+    AsibotConfiguration::JointsIn _qMin, _qMax;
 };
 
 /**
@@ -188,18 +199,13 @@ public:
      * @param qMax vector of maximum joint limits [deg]
      */
     AsibotConfigurationLeastOverallAngularDisplacementFactory(AsibotConfiguration::JointsIn qMin, AsibotConfiguration::JointsIn qMax)
-        : _qMin(qMin), _qMax(qMax)
+        : AsibotConfigurationFactory(qMin, qMax)
     {}
 
     virtual AsibotConfiguration * create() const
     {
         return new AsibotConfigurationLeastOverallAngularDisplacement(_qMin, _qMax);
     }
-
-private:
-
-    AsibotConfiguration::JointsIn _qMin;
-    AsibotConfiguration::JointsIn _qMax;
 };
 
 }  // namespace roboticslab

--- a/libraries/YarpPlugins/AsibotSolver/AsibotSolver.hpp
+++ b/libraries/YarpPlugins/AsibotSolver/AsibotSolver.hpp
@@ -3,6 +3,7 @@
 #ifndef __ASIBOT_SOLVER_HPP__
 #define __ASIBOT_SOLVER_HPP__
 
+#include <string>
 #include <vector>
 
 #include <yarp/os/Searchable.h>
@@ -41,7 +42,7 @@ public:
 
     AsibotSolver()
         : A0(DEFAULT_A0), A1(DEFAULT_A1), A2(DEFAULT_A2), A3(DEFAULT_A3),
-          conf(NULL)
+          confFactory(NULL)
     {}
 
 // -------- ICartesianSolver declarations. Implementation in ICartesianSolverImpl.cpp --------
@@ -104,11 +105,19 @@ public:
 
 private:
 
+    // defined in DeviceDriverImpl.cpp
+    bool buildStrategyFactory(const std::string & strategy);
+
+    AsibotConfiguration * getConfiguration() const
+    {
+        return confFactory->create();
+    }
+
     double A0, A1, A2, A3;  // link lengths
 
     std::vector<double> qMin, qMax;
 
-    AsibotConfiguration * conf;
+    AsibotConfigurationFactory * confFactory;
 };
 
 }  // namespace roboticslab

--- a/libraries/YarpPlugins/AsibotSolver/DeviceDriverImpl.cpp
+++ b/libraries/YarpPlugins/AsibotSolver/DeviceDriverImpl.cpp
@@ -74,11 +74,7 @@ bool roboticslab::AsibotSolver::open(yarp::os::Searchable& config)
 
     std::string strategy = config.check("invKinStrategy", yarp::os::Value(DEFAULT_STRATEGY), "IK configuration strategy").asString();
 
-    if (strategy == DEFAULT_STRATEGY)
-    {
-        conf = new AsibotConfigurationLeastOverallAngularDisplacement(qMin, qMax);
-    }
-    else
+    if (!buildStrategyFactory(strategy))
     {
         CD_ERROR("Unsupported IK configuration strategy: %s.\n", strategy.c_str());
         return false;
@@ -95,8 +91,28 @@ bool roboticslab::AsibotSolver::open(yarp::os::Searchable& config)
 // -----------------------------------------------------------------------------
 
 bool roboticslab::AsibotSolver::close() {
-    delete conf;
-    conf = NULL;
+    if (confFactory != NULL)
+    {
+        delete confFactory;
+        confFactory = NULL;
+    }
+
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool roboticslab::AsibotSolver::buildStrategyFactory(const std::string & strategy)
+{
+    if (strategy == DEFAULT_STRATEGY)
+    {
+        confFactory = new AsibotConfigurationLeastOverallAngularDisplacementFactory(qMin, qMax);
+    }
+    else
+    {
+        return false;
+    }
+
     return true;
 }
 

--- a/libraries/YarpPlugins/AsibotSolver/ICartesianSolverImpl.cpp
+++ b/libraries/YarpPlugins/AsibotSolver/ICartesianSolverImpl.cpp
@@ -3,6 +3,7 @@
 #include "AsibotSolver.hpp"
 
 #include <cmath>
+#include <memory>
 
 #include <yarp/math/Math.h>
 #include <yarp/math/SVD.h>
@@ -189,6 +190,8 @@ bool roboticslab::AsibotSolver::invKin(const std::vector<double> &xd, const std:
 
     double t3uRad = oyPdRad - t1uRad - t2Rad;
     double t3dRad = oyPdRad - t1dRad + t2Rad;
+
+    std::auto_ptr<AsibotConfiguration> conf(getConfiguration());
 
     if (!conf->configure(KinRepresentation::radToDeg(ozdRad),
             KinRepresentation::radToDeg(t1uRad),

--- a/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
@@ -180,6 +180,11 @@ class BasicCartesianControl : public yarp::dev::DeviceDriver, public ICartesianC
 
     protected:
 
+        void handleMovl();
+        void handleMovv();
+        void handleGcmp();
+        void handleForc();
+
         yarp::dev::PolyDriver solverDevice;
         roboticslab::ICartesianSolver *iCartesianSolver;
 

--- a/libraries/YarpPlugins/BasicCartesianControl/RateThreadImpl.cpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/RateThreadImpl.cpp
@@ -2,161 +2,213 @@
 
 #include "BasicCartesianControl.hpp"
 
-#include <math.h>  //-- fabs
+#include <cmath>  //-- abs
+#include <yarp/os/Time.h>
 #include <ColorDebug.hpp>
 
 // ------------------- RateThread Related ------------------------------------
 
-void roboticslab::BasicCartesianControl::run() {
-
-    int catchCurrentState = getCurrentState();
-
-    if (catchCurrentState == VOCAB_CC_MOVL_CONTROLLING)
+void roboticslab::BasicCartesianControl::run()
+{
+    switch (getCurrentState())
     {
-        double movementTime = yarp::os::Time::now() - movementStartTime;
-
-        if( movementTime > DEFAULT_DURATION )
-        {
-            stopControl();
-            return;
-        }
-
-        //-- Obtain current joint position
-        std::vector<double> currentQ(numRobotJoints);
-        if ( ! iEncoders->getEncoders( currentQ.data() ) )
-        {
-            CD_WARNING("getEncoders failed, not updating control this iteration.\n");
-            return;
-        }
-
-        //-- Obtain desired Cartesian position and velocity.
-        std::vector<double> desiredX, desiredXdot;
-        trajectory.getX(movementTime, desiredX);
-        trajectory.getXdot(movementTime, desiredXdot);
-
-        //-- Apply control law to compute robot Cartesian velocity commands.
-        std::vector<double> commandXdot;
-        iCartesianSolver->fwdKinError(desiredX,currentQ, commandXdot);
-        for(unsigned int i=0; i<6; i++)
-        {
-            commandXdot[i] *= DEFAULT_GAIN * (1000.0 / DEFAULT_MS);
-            commandXdot[i] += desiredXdot[i];
-        }
-
-        //-- Compute joint velocity commands and send to robot.
-        std::vector<double> commandQdot;
-        if (! iCartesianSolver->diffInvKin(currentQ,commandXdot,commandQdot) )
-        {
-            CD_WARNING("diffInvKin failed, not updating control this iteration.\n");
-            return;
-        }
-
-        CD_DEBUG_NO_HEADER("[MOVL] [%f] ",movementTime);
-        for(int i=0;i<6;i++)
-            CD_DEBUG_NO_HEADER("%f ",commandXdot[i]);
-        CD_DEBUG_NO_HEADER("-> ");
-        for(int i=0;i<numRobotJoints;i++)
-            CD_DEBUG_NO_HEADER("%f ",commandQdot[i]);
-        CD_DEBUG_NO_HEADER("[deg/s]\n");
-
-        for(int i=0;i<commandQdot.size();i++)
-        {
-            if( fabs(commandQdot[i]) > DEFAULT_QDOT_LIMIT)
-            {
-                CD_ERROR("diffInvKin too dangerous, STOP!!!\n");
-                stopControl();
-                return;
-            }
-        }
-
-        if( ! iVelocityControl->velocityMove( commandQdot.data() ) )
-        {
-            CD_WARNING("velocityMove failed, not updating control this iteration.\n");
-        }
+    case VOCAB_CC_MOVL_CONTROLLING:
+        handleMovl();
+        break;
+    case VOCAB_CC_MOVV_CONTROLLING:
+        handleMovv();
+        break;
+    case VOCAB_CC_GCMP_CONTROLLING:
+        handleGcmp();
+        break;
+    case VOCAB_CC_FORC_CONTROLLING:
+        handleForc();
+        break;
+    default:
+        break;
     }
-    else if (catchCurrentState == VOCAB_CC_MOVV_CONTROLLING)
-    {
-        //-- Obtain current joint position
-        std::vector<double> currentQ(numRobotJoints);
-        if ( ! iEncoders->getEncoders( currentQ.data() ) )
-        {
-            CD_WARNING("getEncoders failed, not updating control this iteration.\n");
-            return;
-        }
-
-        //-- Compute joint velocity commands and send to robot.
-        std::vector<double> commandQdot;
-        if (! iCartesianSolver->diffInvKin(currentQ,xdotd,commandQdot) )
-        {
-            CD_WARNING("diffInvKin failed, not updating control this iteration.\n");
-            return;
-        }
-
-        CD_DEBUG_NO_HEADER("[MOVV] ");
-        for(int i=0;i<6;i++)
-            CD_DEBUG_NO_HEADER("%f ",xdotd[i]);
-        CD_DEBUG_NO_HEADER("-> ");
-        for(int i=0;i<numRobotJoints;i++)
-            CD_DEBUG_NO_HEADER("%f ",commandQdot[i]);
-        CD_DEBUG_NO_HEADER("[deg/s]\n");
-
-        for(int i=0;i<commandQdot.size();i++)
-        {
-            if( fabs(commandQdot[i]) > DEFAULT_QDOT_LIMIT)
-            {
-                CD_ERROR("diffInvKin too dangerous, STOP!!!\n");
-                stopControl();
-                return;
-            }
-        }
-
-        if( ! iVelocityControl->velocityMove( commandQdot.data() ) )
-        {
-            CD_WARNING("velocityMove failed, not updating control this iteration.\n");
-        }
-    }
-    else if (catchCurrentState == VOCAB_CC_GCMP_CONTROLLING)
-    {
-        //-- Obtain current joint position
-        std::vector<double> currentQ(numRobotJoints);
-        if ( ! iEncoders->getEncoders( currentQ.data() ) )
-        {
-            CD_WARNING("getEncoders failed, not updating control this iteration.\n");
-            return;
-        }
-
-        std::vector< double > t(numRobotJoints);
-        iCartesianSolver->invDyn(currentQ,t);
-
-        iTorqueControl->setRefTorques( t.data() );
-    }
-    else if (catchCurrentState == VOCAB_CC_FORC_CONTROLLING)
-    {
-        //-- Obtain current joint position
-        std::vector<double> currentQ(numRobotJoints);
-        if ( ! iEncoders->getEncoders( currentQ.data() ) )
-        {
-            CD_WARNING("getEncoders failed, not updating control this iteration.\n");
-            return;
-        }
-
-        std::vector<double> qdot(numRobotJoints,0), qdotdot(numRobotJoints,0);
-        std::vector< std::vector<double> > fexts;
-        for (int i=0; i<numRobotJoints-1; i++)  //-- "numRobotJoints-1" is important
-        {
-            std::vector<double> fext(6,0);
-            fexts.push_back(fext);
-        }
-        fexts.push_back(td);
-
-        std::vector< double > t(numRobotJoints);
-        iCartesianSolver->invDyn(currentQ,qdot,qdotdot,fexts,t);
-
-        iTorqueControl->setRefTorques( t.data() );
-    }
-
-    return;
 }
 
 // -----------------------------------------------------------------------------
 
+void roboticslab::BasicCartesianControl::handleMovl()
+{
+    double movementTime = yarp::os::Time::now() - movementStartTime;
+
+    if (movementTime > DEFAULT_DURATION)
+    {
+        stopControl();
+        return;
+    }
+
+    //-- Obtain current joint position
+    std::vector<double> currentQ(numRobotJoints);
+
+    if (!iEncoders->getEncoders(currentQ.data()))
+    {
+        CD_WARNING("getEncoders failed, not updating control this iteration.\n");
+        return;
+    }
+
+    //-- Obtain desired Cartesian position and velocity.
+    std::vector<double> desiredX, desiredXdot;
+    trajectory.getX(movementTime, desiredX);
+    trajectory.getXdot(movementTime, desiredXdot);
+
+    //-- Apply control law to compute robot Cartesian velocity commands.
+    std::vector<double> commandXdot;
+    iCartesianSolver->fwdKinError(desiredX, currentQ, commandXdot);
+
+    for (int i = 0; i < 6; i++)
+    {
+        commandXdot[i] *= DEFAULT_GAIN * (1000.0 / DEFAULT_MS);
+        commandXdot[i] += desiredXdot[i];
+    }
+
+    //-- Compute joint velocity commands and send to robot.
+    std::vector<double> commandQdot;
+
+    if (!iCartesianSolver->diffInvKin(currentQ, commandXdot, commandQdot))
+    {
+        CD_WARNING("diffInvKin failed, not updating control this iteration.\n");
+        return;
+    }
+
+    CD_DEBUG_NO_HEADER("[MOVL] [%f] ", movementTime);
+
+    for (int i = 0; i < 6; i++)
+    {
+        CD_DEBUG_NO_HEADER("%f ", commandXdot[i]);
+    }
+
+    CD_DEBUG_NO_HEADER("-> ");
+
+    for (int i = 0; i < numRobotJoints; i++)
+    {
+        CD_DEBUG_NO_HEADER("%f ", commandQdot[i]);
+    }
+
+    CD_DEBUG_NO_HEADER("[deg/s]\n");
+
+    for (int i = 0; i < commandQdot.size(); i++)
+    {
+        if (std::abs(commandQdot[i]) > DEFAULT_QDOT_LIMIT)
+        {
+            CD_ERROR("diffInvKin too dangerous, STOP!!!\n");
+            stopControl();
+            return;
+        }
+    }
+
+    if (!iVelocityControl->velocityMove(commandQdot.data()))
+    {
+        CD_WARNING("velocityMove failed, not updating control this iteration.\n");
+    }
+}
+
+// -----------------------------------------------------------------------------
+
+void roboticslab::BasicCartesianControl::handleMovv()
+{
+    //-- Obtain current joint position
+    std::vector<double> currentQ(numRobotJoints);
+
+    if (!iEncoders->getEncoders(currentQ.data()))
+    {
+        CD_WARNING("getEncoders failed, not updating control this iteration.\n");
+        return;
+    }
+
+    //-- Compute joint velocity commands and send to robot.
+    std::vector<double> commandQdot;
+
+    if (!iCartesianSolver->diffInvKin(currentQ, xdotd, commandQdot))
+    {
+        CD_WARNING("diffInvKin failed, not updating control this iteration.\n");
+        return;
+    }
+
+    CD_DEBUG_NO_HEADER("[MOVV] ");
+
+    for (int i = 0; i < 6; i++)
+    {
+        CD_DEBUG_NO_HEADER("%f ", xdotd[i]);
+    }
+
+    CD_DEBUG_NO_HEADER("-> ");
+
+    for (int i = 0; i < numRobotJoints; i++)
+    {
+        CD_DEBUG_NO_HEADER("%f ", commandQdot[i]);
+    }
+
+    CD_DEBUG_NO_HEADER("[deg/s]\n");
+
+    for (int i = 0; i < commandQdot.size(); i++)
+    {
+        if (std::abs(commandQdot[i]) > DEFAULT_QDOT_LIMIT)
+        {
+            CD_ERROR("diffInvKin too dangerous, STOP!!!\n");
+            stopControl();
+            return;
+        }
+    }
+
+    if (!iVelocityControl->velocityMove(commandQdot.data()))
+    {
+        CD_WARNING("velocityMove failed, not updating control this iteration.\n");
+    }
+}
+
+// -----------------------------------------------------------------------------
+
+void roboticslab::BasicCartesianControl::handleGcmp()
+{
+    //-- Obtain current joint position
+    std::vector<double> currentQ(numRobotJoints);
+
+    if (!iEncoders->getEncoders(currentQ.data()))
+    {
+        CD_WARNING("getEncoders failed, not updating control this iteration.\n");
+        return;
+    }
+
+    std::vector<double> t(numRobotJoints);
+
+    iCartesianSolver->invDyn(currentQ, t);
+
+    iTorqueControl->setRefTorques(t.data());
+}
+
+// -----------------------------------------------------------------------------
+
+void roboticslab::BasicCartesianControl::handleForc()
+{
+    //-- Obtain current joint position
+    std::vector<double> currentQ(numRobotJoints);
+
+    if (!iEncoders->getEncoders(currentQ.data()))
+    {
+        CD_WARNING("getEncoders failed, not updating control this iteration.\n");
+        return;
+    }
+
+    std::vector<double> qdot(numRobotJoints, 0), qdotdot(numRobotJoints, 0);
+    std::vector< std::vector<double> > fexts;
+
+    for (int i = 0; i < numRobotJoints - 1; i++)  //-- "numRobotJoints-1" is important
+    {
+        std::vector<double> fext(6, 0);
+        fexts.push_back(fext);
+    }
+
+    fexts.push_back(td);
+
+    std::vector<double> t(numRobotJoints);
+
+    iCartesianSolver->invDyn(currentQ, qdot, qdotdot, fexts, t);
+
+    iTorqueControl->setRefTorques(t.data());
+}
+
+// -----------------------------------------------------------------------------

--- a/libraries/YarpPlugins/CartesianControlClient/CMakeLists.txt
+++ b/libraries/YarpPlugins/CartesianControlClient/CMakeLists.txt
@@ -16,7 +16,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}) # yarp plugin builder needs thi
 
 yarp_add_plugin(CartesianControlClient CartesianControlClient.hpp
                                        DeviceDriverImpl.cpp
-                                       ICartesianControlImpl.cpp)
+                                       ICartesianControlImpl.cpp
+                                       FkStreamResponder.cpp)
 
 add_dependencies(CartesianControlClient COLOR_DEBUG)
 

--- a/libraries/YarpPlugins/CartesianControlClient/CartesianControlClient.hpp
+++ b/libraries/YarpPlugins/CartesianControlClient/CartesianControlClient.hpp
@@ -137,6 +137,8 @@ protected:
     yarp::os::BufferedPort<yarp::os::Bottle> fkInPort, commandPort;
 
     FkStreamResponder fkStreamResponder;
+
+    bool fkStreamEnabled;
 };
 
 }  // namespace roboticslab

--- a/libraries/YarpPlugins/CartesianControlClient/CartesianControlClient.hpp
+++ b/libraries/YarpPlugins/CartesianControlClient/CartesianControlClient.hpp
@@ -4,8 +4,7 @@
 #define __CARTESIAN_CONTROL_CLIENT_HPP__
 
 #include <yarp/os/Bottle.h>
-#include <yarp/os/Port.h>
-#include <yarp/os/PortWriterBuffer.h>
+#include <yarp/os/BufferedPort.h>
 #include <yarp/os/RpcClient.h>
 #include <yarp/dev/Drivers.h>
 #include <yarp/dev/PolyDriver.h>
@@ -107,8 +106,7 @@ protected:
     void handleStreamingBiConsumerCmd(int vocab, const std::vector<double>& in1, double in2);
 
     yarp::os::RpcClient rpcClient;
-    yarp::os::Port commandPort;
-    yarp::os::PortWriterBuffer<yarp::os::Bottle> commandBuffer;
+    yarp::os::BufferedPort<yarp::os::Bottle> commandPort;
 
 };
 

--- a/libraries/YarpPlugins/CartesianControlClient/DeviceDriverImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/DeviceDriverImpl.cpp
@@ -18,9 +18,17 @@ bool roboticslab::CartesianControlClient::open(yarp::os::Searchable& config)
     std::string remote = config.check("cartesianRemote", yarp::os::Value(DEFAULT_CARTESIAN_REMOTE),
             "cartesianRemote").asString();
 
-    rpcClient.open(local + "/rpc:c");
-    commandPort.open(local + "/command:o");
-    fkInPort.open(local + "/state:i");
+    bool portsOk = true;
+
+    portsOk = portsOk && rpcClient.open(local + "/rpc:c");
+    portsOk = portsOk && commandPort.open(local + "/command:o");
+    portsOk = portsOk && fkInPort.open(local + "/state:i");
+
+    if (!portsOk)
+    {
+        CD_ERROR("Unable to open ports.\n");
+        return false;
+    }
 
     int tries = 0;
     const int maxTries = 10;

--- a/libraries/YarpPlugins/CartesianControlClient/DeviceDriverImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/DeviceDriverImpl.cpp
@@ -68,8 +68,6 @@ bool roboticslab::CartesianControlClient::open(yarp::os::Searchable& config)
 
     CD_SUCCESS("Connected to remote.\n");
 
-    commandBuffer.attach(commandPort);
-
     return true;
 }
 
@@ -78,7 +76,6 @@ bool roboticslab::CartesianControlClient::open(yarp::os::Searchable& config)
 bool roboticslab::CartesianControlClient::close()
 {
     rpcClient.close();
-    commandBuffer.detach();
     commandPort.close();
     return true;
 }

--- a/libraries/YarpPlugins/CartesianControlClient/DeviceDriverImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/DeviceDriverImpl.cpp
@@ -47,14 +47,17 @@ bool roboticslab::CartesianControlClient::open(yarp::os::Searchable& config)
 
     if (!yarp::os::Network::connect(remote + "/state:o", fkInPort.getName(), "udp"))
     {
-        CD_ERROR("Error on connect to remote FK stream server.\n");
-        close();  // close ports
-        return false;
+        CD_INFO("FK stream disabled, using RPC instead.\n");
+        fkStreamEnabled = false;
+        fkInPort.close();
+    }
+    else
+    {
+        fkStreamEnabled = true;
+        fkInPort.useCallback(fkStreamResponder);
     }
 
     CD_SUCCESS("Connected to remote.\n");
-
-    fkInPort.useCallback(fkStreamResponder);
 
     return true;
 }
@@ -65,7 +68,11 @@ bool roboticslab::CartesianControlClient::close()
 {
     rpcClient.close();
     commandPort.close();
-    fkInPort.close();
+
+    if (fkStreamEnabled)
+    {
+        fkInPort.close();
+    }
 
     return true;
 }

--- a/libraries/YarpPlugins/CartesianControlClient/FkStreamResponder.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/FkStreamResponder.cpp
@@ -1,0 +1,42 @@
+// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+#include "CartesianControlClient.hpp"
+
+#include <yarp/os/Time.h>
+
+// ------------------- DeviceDriver Related ------------------------------------
+
+void roboticslab::FkStreamResponder::onRead(yarp::os::Bottle & b)
+{
+    mutex.wait();
+
+    now = yarp::os::Time::now();
+    state = b.get(0).asVocab();
+    x.resize(b.size() - 1);
+
+    for (size_t i = 0; i < x.size(); i++)
+    {
+        x[i] = b.get(i + 1).asDouble();
+    }
+
+    mutex.post();
+}
+
+// -----------------------------------------------------------------------------
+
+double roboticslab::FkStreamResponder::getLastStatData(int *state, std::vector<double> &x)
+{
+    double localArrivalTime;
+
+    mutex.wait();
+
+    *state = this->state;
+    x = this->x;
+    localArrivalTime = now;
+
+    mutex.post();
+
+    return localArrivalTime;
+}
+
+// -----------------------------------------------------------------------------

--- a/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
@@ -75,7 +75,7 @@ bool roboticslab::CartesianControlClient::handleRpcFunctionCmd(int vocab, const 
 
 void roboticslab::CartesianControlClient::handleStreamingConsumerCmd(int vocab, const std::vector<double>& in)
 {
-    yarp::os::Bottle& cmd = commandBuffer.get();
+    yarp::os::Bottle& cmd = commandPort.prepare();
 
     cmd.clear();
     cmd.addVocab(vocab);
@@ -85,14 +85,14 @@ void roboticslab::CartesianControlClient::handleStreamingConsumerCmd(int vocab, 
         cmd.addDouble(in[i]);
     }
 
-    commandBuffer.write(true);
+    commandPort.write(true);
 }
 
 // -----------------------------------------------------------------------------
 
 void roboticslab::CartesianControlClient::handleStreamingBiConsumerCmd(int vocab, const std::vector<double>& in1, double in2)
 {
-    yarp::os::Bottle& cmd = commandBuffer.get();
+    yarp::os::Bottle& cmd = commandPort.prepare();
 
     cmd.clear();
     cmd.addVocab(vocab);
@@ -103,7 +103,7 @@ void roboticslab::CartesianControlClient::handleStreamingBiConsumerCmd(int vocab
         cmd.addDouble(in1[i]);
     }
 
-    commandBuffer.write(true);
+    commandPort.write(true);
 }
 
 // -----------------------------------------------------------------------------

--- a/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
@@ -89,7 +89,7 @@ void roboticslab::CartesianControlClient::handleStreamingConsumerCmd(int vocab, 
         cmd.addDouble(in[i]);
     }
 
-    commandPort.write(true);
+    commandPort.write();
 }
 
 // -----------------------------------------------------------------------------
@@ -107,7 +107,7 @@ void roboticslab::CartesianControlClient::handleStreamingBiConsumerCmd(int vocab
         cmd.addDouble(in1[i]);
     }
 
-    commandPort.write(true);
+    commandPort.write();
 }
 
 // -----------------------------------------------------------------------------

--- a/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
@@ -114,14 +114,17 @@ void roboticslab::CartesianControlClient::handleStreamingBiConsumerCmd(int vocab
 
 bool roboticslab::CartesianControlClient::stat(int &state, std::vector<double> &x)
 {
-    double localArrivalTime = fkStreamResponder.getLastStatData(&state, x);
-
-    if (yarp::os::Time::now() - localArrivalTime <= FK_STREAM_TIMEOUT_SECS)
+    if (fkStreamEnabled)
     {
-        return true;
-    }
+        double localArrivalTime = fkStreamResponder.getLastStatData(&state, x);
 
-    CD_WARNING("FK stream timeout, sending RPC request.\n");
+        if (yarp::os::Time::now() - localArrivalTime <= FK_STREAM_TIMEOUT_SECS)
+        {
+            return true;
+        }
+
+        CD_WARNING("FK stream timeout, sending RPC request.\n");
+    }
 
     yarp::os::Bottle cmd, response;
 

--- a/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
@@ -2,6 +2,10 @@
 
 #include "CartesianControlClient.hpp"
 
+#include <yarp/os/Time.h>
+
+#include <ColorDebug.hpp>
+
 // ------------------- ICartesianControl Related ------------------------------------
 
 bool roboticslab::CartesianControlClient::handleRpcRunnableCmd(int vocab)
@@ -110,6 +114,15 @@ void roboticslab::CartesianControlClient::handleStreamingBiConsumerCmd(int vocab
 
 bool roboticslab::CartesianControlClient::stat(int &state, std::vector<double> &x)
 {
+    double localArrivalTime = fkStreamResponder.getLastStatData(&state, x);
+
+    if (yarp::os::Time::now() - localArrivalTime <= FK_STREAM_TIMEOUT_SECS)
+    {
+        return true;
+    }
+
+    CD_WARNING("FK stream timeout, sending RPC request.\n");
+
     yarp::os::Bottle cmd, response;
 
     cmd.addVocab(VOCAB_CC_STAT);

--- a/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
@@ -14,7 +14,7 @@ bool roboticslab::CartesianControlClient::handleRpcRunnableCmd(int vocab)
 
     cmd.addVocab(vocab);
 
-    rpcClient.write(cmd,response);
+    rpcClient.write(cmd, response);
 
     if (response.get(0).isVocab() && response.get(0).asVocab() == VOCAB_FAILED)
     {
@@ -131,6 +131,11 @@ bool roboticslab::CartesianControlClient::stat(int &state, std::vector<double> &
     cmd.addVocab(VOCAB_CC_STAT);
 
     rpcClient.write(cmd, response);
+
+    if (response.get(0).isVocab() && response.get(0).asVocab() == VOCAB_FAILED)
+    {
+        return false;
+    }
 
     state = response.get(0).asVocab();
     x.resize(response.size() - 1);

--- a/libraries/YarpPlugins/CartesianControlServer/CMakeLists.txt
+++ b/libraries/YarpPlugins/CartesianControlServer/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}) # yarp plugin builder needs thi
 
 yarp_add_plugin(CartesianControlServer CartesianControlServer.hpp
                                        DeviceDriverImpl.cpp
+                                       RateThreadImpl.cpp
                                        RpcResponder.cpp
                                        StreamResponder.cpp)
 

--- a/libraries/YarpPlugins/CartesianControlServer/CartesianControlServer.hpp
+++ b/libraries/YarpPlugins/CartesianControlServer/CartesianControlServer.hpp
@@ -13,6 +13,7 @@
 #include "ICartesianControl.h"
 #include "KinematicRepresentation.hpp"
 
+#define DEFAULT_PREFIX "/CartesianServer"
 #define DEFAULT_MS 20
 
 namespace roboticslab
@@ -42,7 +43,8 @@ public:
         : yarp::os::RateThread(DEFAULT_MS),
           iCartesianControl(NULL),
           rpcResponder(NULL), rpcTransformResponder(NULL),
-          streamResponder(NULL)
+          streamResponder(NULL),
+          fkStreamEnabled(true)
     {}
 
     // -------- DeviceDriver declarations. Implementation in IDeviceImpl.cpp --------
@@ -84,6 +86,8 @@ protected:
 
     RpcResponder *rpcResponder, *rpcTransformResponder;
     StreamResponder *streamResponder;
+
+    bool fkStreamEnabled;
 };
 
 /**

--- a/libraries/YarpPlugins/CartesianControlServer/CartesianControlServer.hpp
+++ b/libraries/YarpPlugins/CartesianControlServer/CartesianControlServer.hpp
@@ -75,18 +75,14 @@ public:
 
 protected:
 
+    yarp::dev::PolyDriver cartesianControlDevice;
+
     yarp::os::RpcServer rpcServer, rpcTransformServer;
-
-    yarp::os::Port fkOutPort;
-
-    yarp::os::BufferedPort<yarp::os::Bottle> commandPort;
+    yarp::os::BufferedPort<yarp::os::Bottle> fkOutPort, commandPort;
 
     roboticslab::ICartesianControl *iCartesianControl;
 
-    yarp::dev::PolyDriver cartesianControlDevice;
-
     RpcResponder *rpcResponder, *rpcTransformResponder;
-
     StreamResponder *streamResponder;
 };
 

--- a/libraries/YarpPlugins/CartesianControlServer/CartesianControlServer.hpp
+++ b/libraries/YarpPlugins/CartesianControlServer/CartesianControlServer.hpp
@@ -13,6 +13,8 @@
 #include "ICartesianControl.h"
 #include "KinematicRepresentation.hpp"
 
+#define DEFAULT_MS 20
+
 namespace roboticslab
 {
 
@@ -32,12 +34,13 @@ class StreamResponder;
  * @brief The CartesianControlServer class implements ICartesianControl server side.
  */
 
-class CartesianControlServer : public yarp::dev::DeviceDriver
+class CartesianControlServer : public yarp::dev::DeviceDriver, public yarp::os::RateThread
 {
 public:
 
     CartesianControlServer()
-        : iCartesianControl(NULL),
+        : yarp::os::RateThread(DEFAULT_MS),
+          iCartesianControl(NULL),
           rpcResponder(NULL), rpcTransformResponder(NULL),
           streamResponder(NULL)
     {}
@@ -65,9 +68,16 @@ public:
      */
     virtual bool close();
 
+    /**
+     * Loop function. This is the thread itself.
+     */
+    virtual void run();
+
 protected:
 
     yarp::os::RpcServer rpcServer, rpcTransformServer;
+
+    yarp::os::Port fkOutPort;
 
     yarp::os::BufferedPort<yarp::os::Bottle> commandPort;
 

--- a/libraries/YarpPlugins/CartesianControlServer/DeviceDriverImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/DeviceDriverImpl.cpp
@@ -72,6 +72,12 @@ bool roboticslab::CartesianControlServer::open(yarp::os::Searchable& config)
     rpcServer.setReader(*rpcResponder);
     commandPort.useCallback(*streamResponder);
 
+    if (config.check("fkPeriod"))
+    {
+        int periodInMs = config.find("fkPeriod").asInt();
+        yarp::os::RateThread::setRate(periodInMs);
+    }
+
     yarp::os::RateThread::start();
 
     // check angle representation, leave this block last to allow inner return instruction

--- a/libraries/YarpPlugins/CartesianControlServer/DeviceDriverImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/DeviceDriverImpl.cpp
@@ -55,30 +55,27 @@ bool roboticslab::CartesianControlServer::open(yarp::os::Searchable& config)
     rpcResponder = new RpcResponder(iCartesianControl);
     streamResponder = new StreamResponder(iCartesianControl);
 
-    //Look for the portname to register (--name option)
-    if (config.check("name", name))
-    {
-        rpcServer.open(name->asString() + "/rpc:s");
-        commandPort.open(name->asString() + "/command:i");
-        fkOutPort.open(name->asString() + "/state:o");
-    }
-    else
-    {
-        rpcServer.open("/CartesianControl/rpc:s");
-        commandPort.open("/CartesianControl/command:i");
-        fkOutPort.open("/CartesianControl/state:o");
-    }
+    std::string prefix = config.check("name", yarp::os::Value(DEFAULT_PREFIX), "local port prefix").asString();
+
+    rpcServer.open(prefix + "/rpc:s");
+    commandPort.open(prefix + "/command:i");
 
     rpcServer.setReader(*rpcResponder);
     commandPort.useCallback(*streamResponder);
 
-    if (config.check("fkPeriod"))
-    {
-        int periodInMs = config.find("fkPeriod").asInt();
-        yarp::os::RateThread::setRate(periodInMs);
-    }
+    int periodInMs = config.check("fkPeriod", yarp::os::Value(DEFAULT_MS), "FK stream period").asInt();
 
-    yarp::os::RateThread::start();
+    if (periodInMs >= 0)
+    {
+        fkOutPort.open(prefix + "/state:o");
+
+        yarp::os::RateThread::setRate(periodInMs);
+        yarp::os::RateThread::start();
+    }
+    else
+    {
+        fkStreamEnabled = false;
+    }
 
     // check angle representation, leave this block last to allow inner return instruction
     if (config.check("angleRepr", angleRepr))
@@ -94,15 +91,7 @@ bool roboticslab::CartesianControlServer::open(yarp::os::Searchable& config)
 
         rpcTransformResponder = new RpcTransformResponder(iCartesianControl, orient);
 
-        if (config.check("name", name))
-        {
-            rpcTransformServer.open(name->asString() + "/rpc_transform:s");
-        }
-        else
-        {
-            rpcTransformServer.open("/CartesianControl/rpc_transform:s");
-        }
-
+        rpcTransformServer.open(prefix + "/rpc_transform:s");
         rpcTransformServer.setReader(*rpcTransformResponder);
     }
 
@@ -113,10 +102,13 @@ bool roboticslab::CartesianControlServer::open(yarp::os::Searchable& config)
 
 bool roboticslab::CartesianControlServer::close()
 {
-    yarp::os::RateThread::stop();
+    if (fkStreamEnabled)
+    {
+        yarp::os::RateThread::stop();
 
-    fkOutPort.interrupt();
-    fkOutPort.close();
+        fkOutPort.interrupt();
+        fkOutPort.close();
+    }
 
     rpcServer.interrupt();
     rpcServer.close();

--- a/libraries/YarpPlugins/CartesianControlServer/DeviceDriverImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/DeviceDriverImpl.cpp
@@ -60,15 +60,19 @@ bool roboticslab::CartesianControlServer::open(yarp::os::Searchable& config)
     {
         rpcServer.open(name->asString() + "/rpc:s");
         commandPort.open(name->asString() + "/command:i");
+        fkOutPort.open(name->asString() + "/state:o");
     }
     else
     {
         rpcServer.open("/CartesianControl/rpc:s");
         commandPort.open("/CartesianControl/command:i");
+        fkOutPort.open("/CartesianControl/state:o");
     }
 
     rpcServer.setReader(*rpcResponder);
     commandPort.useCallback(*streamResponder);
+
+    yarp::os::RateThread::start();
 
     // check angle representation, leave this block last to allow inner return instruction
     if (config.check("angleRepr", angleRepr))
@@ -103,6 +107,11 @@ bool roboticslab::CartesianControlServer::open(yarp::os::Searchable& config)
 
 bool roboticslab::CartesianControlServer::close()
 {
+    yarp::os::RateThread::stop();
+
+    fkOutPort.interrupt();
+    fkOutPort.close();
+
     rpcServer.interrupt();
     rpcServer.close();
     delete rpcResponder;

--- a/libraries/YarpPlugins/CartesianControlServer/RateThreadImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/RateThreadImpl.cpp
@@ -17,6 +17,7 @@ void roboticslab::CartesianControlServer::run()
     }
 
     yarp::os::Bottle &out = fkOutPort.prepare();
+    out.clear();
     out.addVocab(state);
 
     for (size_t i = 0; i < x.size(); i++)

--- a/libraries/YarpPlugins/CartesianControlServer/RateThreadImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/RateThreadImpl.cpp
@@ -1,0 +1,31 @@
+// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+#include "CartesianControlServer.hpp"
+
+#include <vector>
+
+// ------------------- RateThread related ------------------------------------
+
+void roboticslab::CartesianControlServer::run()
+{
+    std::vector<double> x;
+    int state;
+
+    if (!iCartesianControl->stat(state, x))
+    {
+        return;
+    }
+
+    yarp::os::Bottle out;
+
+    for (size_t i = 0; i < x.size(); i++)
+    {
+        out.addDouble(x[i]);
+    }
+
+    fkOutPort.write(out);
+
+    return;
+}
+
+// -----------------------------------------------------------------------------

--- a/libraries/YarpPlugins/CartesianControlServer/RateThreadImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/RateThreadImpl.cpp
@@ -16,14 +16,15 @@ void roboticslab::CartesianControlServer::run()
         return;
     }
 
-    yarp::os::Bottle out;
+    yarp::os::Bottle &out = fkOutPort.prepare();
+    out.addVocab(state);
 
     for (size_t i = 0; i < x.size(); i++)
     {
         out.addDouble(x[i]);
     }
 
-    fkOutPort.write(out);
+    fkOutPort.write();
 
     return;
 }

--- a/libraries/YarpPlugins/KdlSolver/DeviceDriverImpl.cpp
+++ b/libraries/YarpPlugins/KdlSolver/DeviceDriverImpl.cpp
@@ -215,3 +215,23 @@ bool roboticslab::KdlSolver::getMatrixFromProperties(yarp::os::Searchable &optio
 }
 
 // -----------------------------------------------------------------------------
+
+KDL::Chain roboticslab::KdlSolver::getChain() const
+{
+    KDL::Chain localChain;
+    mutex.wait();
+    localChain = chain;
+    mutex.post();
+    return localChain;
+}
+
+// -----------------------------------------------------------------------------
+
+void roboticslab::KdlSolver::setChain(const KDL::Chain & chain)
+{
+    mutex.wait();
+    this->chain = chain;
+    mutex.post();
+}
+
+// -----------------------------------------------------------------------------

--- a/libraries/YarpPlugins/KdlSolver/ICartesianSolverImpl.cpp
+++ b/libraries/YarpPlugins/KdlSolver/ICartesianSolverImpl.cpp
@@ -22,145 +22,172 @@
 
 // -----------------------------------------------------------------------------
 
-bool roboticslab::KdlSolver::getNumJoints(int* numJoints) {
+bool roboticslab::KdlSolver::getNumJoints(int* numJoints)
+{
     *numJoints = getChain().getNrOfJoints();
     return true;
 }
 
 // -----------------------------------------------------------------------------
 
-bool roboticslab::KdlSolver::appendLink(const std::vector<double>& x) {
+bool roboticslab::KdlSolver::appendLink(const std::vector<double>& x)
+{
     KDL::Frame frameX = KdlVectorConverter::vectorToFrame(x);
+
     KDL::Chain chain = getChain();
     chain.addSegment(KDL::Segment(KDL::Joint(KDL::Joint::None), frameX));
     setChain(chain);
+
     return true;
 }
 
 // -----------------------------------------------------------------------------
 
-bool roboticslab::KdlSolver::restoreOriginalChain() {
+bool roboticslab::KdlSolver::restoreOriginalChain()
+{
     setChain(originalChain);
     return true;
 }
 
 // -----------------------------------------------------------------------------
 
-bool roboticslab::KdlSolver::fwdKin(const std::vector<double> &q, std::vector<double> &x) {
-
+bool roboticslab::KdlSolver::fwdKin(const std::vector<double> &q, std::vector<double> &x)
+{
     const KDL::Chain & chain = getChain();
-    KDL::JntArray qInRad = KDL::JntArray(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
+    KDL::JntArray qInRad(chain.getNrOfJoints());
+
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
         qInRad(motor) = KinRepresentation::degToRad(q[motor]);
+    }
 
     //-- Main fwdKin (pos) solver lines
+    KDL::ChainFkSolverPos_recursive fksolver(chain);
     KDL::Frame fOutCart;
-    KDL::ChainFkSolverPos_recursive fksolver = KDL::ChainFkSolverPos_recursive(chain);
-    fksolver.JntToCart(qInRad,fOutCart);
+    fksolver.JntToCart(qInRad, fOutCart);
 
     x = KdlVectorConverter::frameToVector(fOutCart);
+
     return true;
 }
 
 // -----------------------------------------------------------------------------
 
-bool roboticslab::KdlSolver::fwdKinError(const std::vector<double> &xd, const std::vector<double> &q, std::vector<double> &x) {
-
+bool roboticslab::KdlSolver::fwdKinError(const std::vector<double> &xd, const std::vector<double> &q, std::vector<double> &x)
+{
     KDL::Frame frameXd = KdlVectorConverter::vectorToFrame(xd);
-    const KDL::Chain & chain = getChain();
 
-    KDL::JntArray qInRad = KDL::JntArray(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
+    const KDL::Chain & chain = getChain();
+    KDL::JntArray qInRad(chain.getNrOfJoints());
+
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
         qInRad(motor) = KinRepresentation::degToRad(q[motor]);
+    }
 
     //-- Main fwdKin (pos) solver lines
-    KDL::Frame f;
-    KDL::ChainFkSolverPos_recursive fksolver = KDL::ChainFkSolverPos_recursive(chain);
-    fksolver.JntToCart(qInRad,f);
+    KDL::ChainFkSolverPos_recursive fksolver(chain);
+    KDL::Frame fOutCart;
+    fksolver.JntToCart(qInRad, fOutCart);
 
-    KDL::Twist d = KDL::diff(f,frameXd);
-    x = KdlVectorConverter::twistToVector(d);
+    KDL::Twist diff = KDL::diff(fOutCart, frameXd);
+    x = KdlVectorConverter::twistToVector(diff);
 
     return true;
 }
 
 // -----------------------------------------------------------------------------
 
-bool roboticslab::KdlSolver::invKin(const std::vector<double> &xd, const std::vector<double> &qGuess, std::vector<double> &q) {
-
+bool roboticslab::KdlSolver::invKin(const std::vector<double> &xd, const std::vector<double> &qGuess, std::vector<double> &q)
+{
     KDL::Frame frameXd = KdlVectorConverter::vectorToFrame(xd);
-    const KDL::Chain & chain = getChain();
 
+    const KDL::Chain & chain = getChain();
     KDL::JntArray qGuessInRad = KDL::JntArray(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
+
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
         qGuessInRad(motor) = KinRepresentation::degToRad(qGuess[motor]);
-    KDL::JntArray kdlq = KDL::JntArray(chain.getNrOfJoints());
+    }
+
+    KDL::JntArray kdlq(chain.getNrOfJoints());
 
 #ifdef _USE_LMA_
 
-    Eigen::Matrix<double,6,1> L;
-    L(0)=1;L(1)=1;L(2)=1;
-    L(3)=0;L(4)=0;L(5)=0;
-
+    Eigen::Matrix<double, 6, 1> L;
+    L(0) = 1; L(1) = 1; L(2) = 1;
+    L(3) = 0; L(4) = 0; L(5) = 0;
 
     //-- Main invKin (pos) solver lines
-    KDL::ChainIkSolverPos_LMA iksolver_pos(chain,L);
+    KDL::ChainIkSolverPos_LMA iksolver_pos(chain, L);
 
 #else //_USE_LMA_
 
-    //Forward solvers, needed by the geometric solver
+    //-- Forward solvers, needed by the geometric solver
     KDL::ChainFkSolverPos_recursive fksolver(chain);
     KDL::ChainIkSolverVel_pinv iksolver(chain);  // _givens
 
-    //Geometric solver definition (with joint limits)
-    KDL::ChainIkSolverPos_NR_JL iksolver_pos(chain,qMin,qMax,fksolver,iksolver,maxIter,eps);
+    //-- Geometric solver definition (with joint limits)
+    KDL::ChainIkSolverPos_NR_JL iksolver_pos(chain, qMin, qMax, fksolver, iksolver, maxIter, eps);
 
 #endif //_USE_LMA_
 
-    int ret = iksolver_pos.CartToJnt(qGuessInRad,frameXd,kdlq);
+    int ret = iksolver_pos.CartToJnt(qGuessInRad, frameXd, kdlq);
 
-    if(ret < 0)
+    if (ret < 0)
     {
-        CD_ERROR("%d: %s\n",ret,iksolver_pos.strError(ret));
+        CD_ERROR("%d: %s\n", ret, iksolver_pos.strError(ret));
         return false;
     }
-
-    if(ret > 0)
-        CD_WARNING("%d: %s\n",ret, iksolver_pos.strError(ret));
+    else if (ret > 0)
+    {
+        CD_WARNING("%d: %s\n", ret, iksolver_pos.strError(ret));
+    }
 
     q.resize(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
+
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
         q[motor] = KinRepresentation::radToDeg(kdlq(motor));
+    }
 
     return true;
 }
 
 // -----------------------------------------------------------------------------
 
-bool roboticslab::KdlSolver::diffInvKin(const std::vector<double> &q, const std::vector<double> &xdot, std::vector<double> &qdot) {
-
+bool roboticslab::KdlSolver::diffInvKin(const std::vector<double> &q, const std::vector<double> &xdot, std::vector<double> &qdot)
+{
     const KDL::Chain & chain = getChain();
-    KDL::JntArray qInRad = KDL::JntArray(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
-        qInRad(motor) = KinRepresentation::degToRad(q[motor]);
+    KDL::JntArray qInRad(chain.getNrOfJoints());
 
-    KDL::Twist kdlxdot = KdlVectorConverter::vectorToTwist(xdot);
-    KDL::JntArray qDotOutRadS = KDL::JntArray(chain.getNrOfJoints());
-    KDL::ChainIkSolverVel_pinv iksolverv(chain);
-    int ret = iksolverv.CartToJnt(qInRad,kdlxdot,qDotOutRadS);
-
-    if(ret < 0)
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
     {
-        CD_ERROR("%d: %s\n",ret,iksolverv.strError(ret));
-        return false;
+        qInRad(motor) = KinRepresentation::degToRad(q[motor]);
     }
 
-    if(ret > 0)
-        CD_WARNING("%d: %s\n",ret, iksolverv.strError(ret));
+    KDL::ChainIkSolverVel_pinv iksolverv(chain);
+    KDL::Twist kdlxdot = KdlVectorConverter::vectorToTwist(xdot);
+    KDL::JntArray qDotOutRadS(chain.getNrOfJoints());
+
+    int ret = iksolverv.CartToJnt(qInRad, kdlxdot, qDotOutRadS);
+
+    if (ret < 0)
+    {
+        CD_ERROR("%d: %s\n", ret, iksolverv.strError(ret));
+        return false;
+    }
+    else if (ret > 0)
+    {
+        CD_WARNING("%d: %s\n", ret, iksolverv.strError(ret));
+    }
 
     qdot.resize(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
+
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
         qdot[motor] = KinRepresentation::radToDeg(qDotOutRadS(motor));
+    }
 
     return true;
 }
@@ -170,121 +197,148 @@ bool roboticslab::KdlSolver::diffInvKin(const std::vector<double> &q, const std:
 bool roboticslab::KdlSolver::diffInvKinEE(const std::vector<double> &q, const std::vector<double> &xdotee, std::vector<double> &qdot) {
 
     const KDL::Chain & chain = getChain();
-    KDL::JntArray qInRad = KDL::JntArray(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
+    KDL::JntArray qInRad(chain.getNrOfJoints());
+
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
         qInRad(motor) = KinRepresentation::degToRad(q[motor]);
+    }
+
+    KDL::ChainFkSolverPos_recursive fksolver(chain);
+    KDL::Frame fOutCart;
+    fksolver.JntToCart(qInRad, fOutCart);
 
     KDL::Twist kdlxdotee = KdlVectorConverter::vectorToTwist(xdotee);
 
-    KDL::Frame fOutCart;
-    KDL::ChainFkSolverPos_recursive fksolver = KDL::ChainFkSolverPos_recursive(chain);
-    fksolver.JntToCart(qInRad,fOutCart);
-
-    // transform the basis to which the twist is expressed, but leave the reference point intact
-    // "Twist and Wrench transformations" @ http://docs.ros.org/latest/api/orocos_kdl/html/geomprim.html
+    //-- Transform the basis to which the twist is expressed, but leave the reference point intact
+    //-- "Twist and Wrench transformations" @ http://docs.ros.org/latest/api/orocos_kdl/html/geomprim.html
     KDL::Twist kdlxdot = fOutCart.M * kdlxdotee;
 
-    KDL::JntArray qDotOutRadS = KDL::JntArray(chain.getNrOfJoints());
     KDL::ChainIkSolverVel_pinv iksolverv(chain);
-    int ret = iksolverv.CartToJnt(qInRad,kdlxdot,qDotOutRadS);
+    KDL::JntArray qDotOutRadS(chain.getNrOfJoints());
 
-    if(ret < 0)
+    int ret = iksolverv.CartToJnt(qInRad, kdlxdot, qDotOutRadS);
+
+    if (ret < 0)
     {
-        CD_ERROR("%d: %s\n",ret,iksolverv.strError(ret));
+        CD_ERROR("%d: %s\n", ret, iksolverv.strError(ret));
         return false;
     }
-
-    if(ret > 0)
-        CD_WARNING("%d: %s\n",ret, iksolverv.strError(ret));
+    else if (ret > 0)
+    {
+        CD_WARNING("%d: %s\n", ret, iksolverv.strError(ret));
+    }
 
     qdot.resize(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
+
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
         qdot[motor] = KinRepresentation::radToDeg(qDotOutRadS(motor));
-
-    return true;
-}
-
-// -----------------------------------------------------------------------------
-
-bool roboticslab::KdlSolver::invDyn(const std::vector<double> &q,std::vector<double> &t) {
-
-    const KDL::Chain & chain = getChain();
-    KDL::JntArray qInRad = KDL::JntArray(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
-        qInRad(motor) = KinRepresentation::degToRad(q[motor]);
-
-    KDL::JntArray qdotInRad = KDL::JntArray(chain.getNrOfJoints());
-    qdotInRad.data.setZero();
-
-    KDL::JntArray qdotdotInRad = KDL::JntArray(chain.getNrOfJoints());
-    qdotdotInRad.data.setZero();
-
-    KDL::Wrenches wrenches(chain.getNrOfSegments(),KDL::Wrench::Zero());
-
-    KDL::JntArray kdlt = KDL::JntArray(chain.getNrOfJoints());
-
-    //-- Main invDyn solver lines
-    KDL::ChainIdSolver_RNE idsolver(chain,gravity);
-    int ret = idsolver.CartToJnt(qInRad,qdotInRad,qdotdotInRad,wrenches,kdlt);
-
-    if(ret < 0)
-    {
-        CD_ERROR("%d: %s\n",ret,idsolver.strError(ret));
-        return false;
     }
 
-    if(ret > 0)
-        CD_WARNING("%d: %s\n",ret, idsolver.strError(ret));
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+
+bool roboticslab::KdlSolver::invDyn(const std::vector<double> &q,std::vector<double> &t)
+{
+    const KDL::Chain & chain = getChain();
+    KDL::JntArray qInRad(chain.getNrOfJoints());
+
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
+        qInRad(motor) = KinRepresentation::degToRad(q[motor]);
+    }
+
+    KDL::JntArray qdotInRad(chain.getNrOfJoints());
+    KDL::JntArray qdotdotInRad(chain.getNrOfJoints());
+
+    KDL::Wrenches wrenches(chain.getNrOfSegments(), KDL::Wrench::Zero());
+    KDL::JntArray kdlt(chain.getNrOfJoints());
+
+    //-- Main invDyn solver lines
+    KDL::ChainIdSolver_RNE idsolver(chain, gravity);
+    int ret = idsolver.CartToJnt(qInRad, qdotInRad, qdotdotInRad, wrenches, kdlt);
+
+    if (ret < 0)
+    {
+        CD_ERROR("%d: %s\n", ret, idsolver.strError(ret));
+        return false;
+    }
+    else if (ret > 0)
+    {
+        CD_WARNING("%d: %s\n", ret, idsolver.strError(ret));
+    }
 
     t.resize(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
-        t[motor]=kdlt(motor);
+
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
+        t[motor] = kdlt(motor);
+    }
 
     return true;
 }
 
 // -----------------------------------------------------------------------------
 
-bool roboticslab::KdlSolver::invDyn(const std::vector<double> &q,const std::vector<double> &qdot,const std::vector<double> &qdotdot, const std::vector< std::vector<double> > &fexts, std::vector<double> &t) {
-
+bool roboticslab::KdlSolver::invDyn(const std::vector<double> &q,const std::vector<double> &qdot,const std::vector<double> &qdotdot, const std::vector< std::vector<double> > &fexts, std::vector<double> &t)
+{
     const KDL::Chain & chain = getChain();
-    KDL::JntArray qInRad = KDL::JntArray(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
-        qInRad(motor) = KinRepresentation::degToRad(q[motor]);
+    KDL::JntArray qInRad(chain.getNrOfJoints());
 
-    KDL::JntArray qdotInRad = KDL::JntArray(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
+        qInRad(motor) = KinRepresentation::degToRad(q[motor]);
+    }
+
+    KDL::JntArray qdotInRad(chain.getNrOfJoints());
+
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
         qdotInRad(motor) = KinRepresentation::degToRad(qdot[motor]);
-
-    KDL::JntArray qdotdotInRad = KDL::JntArray(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
-        qdotdotInRad(motor) = KinRepresentation::degToRad(qdotdot[motor]);
-
-    KDL::Wrenches wrenches = KDL::Wrenches(chain.getNrOfSegments(),KDL::Wrench::Zero());
-    for (int i=0; i<fexts.size(); i++)
-    {
-        KDL::Wrench wrench( KDL::Vector(fexts[i][0],fexts[i][1],fexts[i][2]), KDL::Vector(fexts[i][3],fexts[i][4],fexts[i][5]) );
-        wrenches[i] = wrench;
     }
 
-    KDL::JntArray kdlt = KDL::JntArray(chain.getNrOfJoints());
+    KDL::JntArray qdotdotInRad(chain.getNrOfJoints());
+
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
+        qdotdotInRad(motor) = KinRepresentation::degToRad(qdotdot[motor]);
+    }
+
+    KDL::Wrenches wrenches(chain.getNrOfSegments(), KDL::Wrench::Zero());
+
+    for (int i = 0; i < fexts.size(); i++)
+    {
+        wrenches[i] = KDL::Wrench(
+            KDL::Vector(fexts[i][0], fexts[i][1], fexts[i][2]),
+            KDL::Vector(fexts[i][3], fexts[i][4], fexts[i][5])
+        );
+    }
+
+    KDL::JntArray kdlt(chain.getNrOfJoints());
 
     //-- Main invDyn solver lines
-    KDL::ChainIdSolver_RNE idsolver(chain,gravity);
-    int ret = idsolver.CartToJnt(qInRad,qdotInRad,qdotdotInRad,wrenches,kdlt);
+    KDL::ChainIdSolver_RNE idsolver(chain, gravity);
+    int ret = idsolver.CartToJnt(qInRad, qdotInRad, qdotdotInRad, wrenches, kdlt);
 
-    if(ret < 0)
+    if (ret < 0)
     {
-        CD_ERROR("%d: %s\n",ret,idsolver.strError(ret));
+        CD_ERROR("%d: %s\n", ret, idsolver.strError(ret));
         return false;
     }
-
-    if(ret > 0)
-        CD_WARNING("%d: %s\n",ret,idsolver.strError(ret));
+    else if (ret > 0)
+    {
+        CD_WARNING("%d: %s\n", ret, idsolver.strError(ret));
+    }
 
     t.resize(chain.getNrOfJoints());
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
-        t[motor]=kdlt(motor);
+
+    for (int motor = 0; motor < chain.getNrOfJoints(); motor++)
+    {
+        t[motor] = kdlt(motor);
+    }
 
     return true;
 }
@@ -293,7 +347,7 @@ bool roboticslab::KdlSolver::invDyn(const std::vector<double> &q,const std::vect
 
 bool roboticslab::KdlSolver::setLimits(const std::vector<double> &qMin, const std::vector<double> &qMax)
 {
-    for (int motor=0; motor<getChain().getNrOfJoints(); motor++)
+    for (int motor = 0; motor < getChain().getNrOfJoints(); motor++)
     {
         this->qMax(motor) = KinRepresentation::degToRad(qMax[motor]);
         this->qMin(motor) = KinRepresentation::degToRad(qMin[motor]);

--- a/libraries/YarpPlugins/KdlSolver/ICartesianSolverImpl.cpp
+++ b/libraries/YarpPlugins/KdlSolver/ICartesianSolverImpl.cpp
@@ -23,7 +23,7 @@
 // -----------------------------------------------------------------------------
 
 bool roboticslab::KdlSolver::getNumJoints(int* numJoints) {
-    *numJoints = this->chain.getNrOfJoints();
+    *numJoints = getChain().getNrOfJoints();
     return true;
 }
 
@@ -31,14 +31,16 @@ bool roboticslab::KdlSolver::getNumJoints(int* numJoints) {
 
 bool roboticslab::KdlSolver::appendLink(const std::vector<double>& x) {
     KDL::Frame frameX = KdlVectorConverter::vectorToFrame(x);
+    KDL::Chain chain = getChain();
     chain.addSegment(KDL::Segment(KDL::Joint(KDL::Joint::None), frameX));
+    setChain(chain);
     return true;
 }
 
 // -----------------------------------------------------------------------------
 
 bool roboticslab::KdlSolver::restoreOriginalChain() {
-    chain = originalChain;  // We have: Chain& operator = (const Chain& arg);
+    setChain(originalChain);
     return true;
 }
 
@@ -46,6 +48,7 @@ bool roboticslab::KdlSolver::restoreOriginalChain() {
 
 bool roboticslab::KdlSolver::fwdKin(const std::vector<double> &q, std::vector<double> &x) {
 
+    const KDL::Chain & chain = getChain();
     KDL::JntArray qInRad = KDL::JntArray(chain.getNrOfJoints());
     for (int motor=0; motor<chain.getNrOfJoints(); motor++)
         qInRad(motor) = KinRepresentation::degToRad(q[motor]);
@@ -64,6 +67,7 @@ bool roboticslab::KdlSolver::fwdKin(const std::vector<double> &q, std::vector<do
 bool roboticslab::KdlSolver::fwdKinError(const std::vector<double> &xd, const std::vector<double> &q, std::vector<double> &x) {
 
     KDL::Frame frameXd = KdlVectorConverter::vectorToFrame(xd);
+    const KDL::Chain & chain = getChain();
 
     KDL::JntArray qInRad = KDL::JntArray(chain.getNrOfJoints());
     for (int motor=0; motor<chain.getNrOfJoints(); motor++)
@@ -85,6 +89,7 @@ bool roboticslab::KdlSolver::fwdKinError(const std::vector<double> &xd, const st
 bool roboticslab::KdlSolver::invKin(const std::vector<double> &xd, const std::vector<double> &qGuess, std::vector<double> &q) {
 
     KDL::Frame frameXd = KdlVectorConverter::vectorToFrame(xd);
+    const KDL::Chain & chain = getChain();
 
     KDL::JntArray qGuessInRad = KDL::JntArray(chain.getNrOfJoints());
     for (int motor=0; motor<chain.getNrOfJoints(); motor++)
@@ -134,6 +139,7 @@ bool roboticslab::KdlSolver::invKin(const std::vector<double> &xd, const std::ve
 
 bool roboticslab::KdlSolver::diffInvKin(const std::vector<double> &q, const std::vector<double> &xdot, std::vector<double> &qdot) {
 
+    const KDL::Chain & chain = getChain();
     KDL::JntArray qInRad = KDL::JntArray(chain.getNrOfJoints());
     for (int motor=0; motor<chain.getNrOfJoints(); motor++)
         qInRad(motor) = KinRepresentation::degToRad(q[motor]);
@@ -163,6 +169,7 @@ bool roboticslab::KdlSolver::diffInvKin(const std::vector<double> &q, const std:
 
 bool roboticslab::KdlSolver::diffInvKinEE(const std::vector<double> &q, const std::vector<double> &xdotee, std::vector<double> &qdot) {
 
+    const KDL::Chain & chain = getChain();
     KDL::JntArray qInRad = KDL::JntArray(chain.getNrOfJoints());
     for (int motor=0; motor<chain.getNrOfJoints(); motor++)
         qInRad(motor) = KinRepresentation::degToRad(q[motor]);
@@ -201,6 +208,7 @@ bool roboticslab::KdlSolver::diffInvKinEE(const std::vector<double> &q, const st
 
 bool roboticslab::KdlSolver::invDyn(const std::vector<double> &q,std::vector<double> &t) {
 
+    const KDL::Chain & chain = getChain();
     KDL::JntArray qInRad = KDL::JntArray(chain.getNrOfJoints());
     for (int motor=0; motor<chain.getNrOfJoints(); motor++)
         qInRad(motor) = KinRepresentation::degToRad(q[motor]);
@@ -239,6 +247,7 @@ bool roboticslab::KdlSolver::invDyn(const std::vector<double> &q,std::vector<dou
 
 bool roboticslab::KdlSolver::invDyn(const std::vector<double> &q,const std::vector<double> &qdot,const std::vector<double> &qdotdot, const std::vector< std::vector<double> > &fexts, std::vector<double> &t) {
 
+    const KDL::Chain & chain = getChain();
     KDL::JntArray qInRad = KDL::JntArray(chain.getNrOfJoints());
     for (int motor=0; motor<chain.getNrOfJoints(); motor++)
         qInRad(motor) = KinRepresentation::degToRad(q[motor]);
@@ -284,7 +293,7 @@ bool roboticslab::KdlSolver::invDyn(const std::vector<double> &q,const std::vect
 
 bool roboticslab::KdlSolver::setLimits(const std::vector<double> &qMin, const std::vector<double> &qMax)
 {
-    for (int motor=0; motor<chain.getNrOfJoints(); motor++)
+    for (int motor=0; motor<getChain().getNrOfJoints(); motor++)
     {
         this->qMax(motor) = KinRepresentation::degToRad(qMax[motor]);
         this->qMin(motor) = KinRepresentation::degToRad(qMin[motor]);

--- a/libraries/YarpPlugins/KdlSolver/KdlSolver.hpp
+++ b/libraries/YarpPlugins/KdlSolver/KdlSolver.hpp
@@ -111,6 +111,12 @@ class KdlSolver : public yarp::dev::DeviceDriver, public ICartesianSolver
 
     protected:
 
+        // defined in DeviceDriverImpl.cpp
+        KDL::Chain getChain() const;
+        void setChain(const KDL::Chain & chain);
+
+        mutable yarp::os::Semaphore mutex;
+
         /** The chain. **/
         KDL::Chain chain;
 


### PR DESCRIPTION
Resolves #102. Marking as work in progress: needs proper testing (preferably with high-frequency, streaming commands) so that we make sure there are no race conditions caused by concurrent access.

A few design decisions were inspired by YARP's remote_controlboard & controlboardwrapper2 devices. It's worth noting that this pair sends/receives timestamp envelopes along with actual data (e.g. encoder values, control mode, etc.). In the future, we could take advantage of this technique to provide a more accurate way of describing cartesian position and current motion status.