### PR TITLE
Add ICartesianControl::wait

### DIFF
--- a/libraries/YarpPlugins/AmorCartesianControl/AmorCartesianControl.cpp
+++ b/libraries/YarpPlugins/AmorCartesianControl/AmorCartesianControl.cpp
@@ -4,37 +4,7 @@
 
 #include <cmath>
 
-#include <yarp/os/Time.h>
-
 #include <ColorDebug.hpp>
-
-// -----------------------------------------------------------------------------
-
-bool roboticslab::AmorCartesianControl::waitForCompletion(int vocab)
-{
-    currentState = vocab;
-
-    AMOR_RESULT res;
-    amor_movement_status status;
-
-    do
-    {
-        res = amor_get_movement_status(handle, &status);
-
-        if (res == AMOR_FAILED)
-        {
-            CD_ERROR("%s\n", amor_error());
-            break;
-        }
-
-        yarp::os::Time::delay(0.5);  // seconds
-    }
-    while (status != AMOR_MOVEMENT_STATUS_FINISHED);
-
-    currentState = VOCAB_CC_NOT_CONTROLLING;
-
-    return res == AMOR_SUCCESS;
-}
 
 // -----------------------------------------------------------------------------
 

--- a/libraries/YarpPlugins/AmorCartesianControl/AmorCartesianControl.hpp
+++ b/libraries/YarpPlugins/AmorCartesianControl/AmorCartesianControl.hpp
@@ -109,8 +109,6 @@ public:
 
 private:
 
-    bool waitForCompletion(int vocab);
-
     bool checkJointVelocities(const std::vector<double> &qdot);
 
     bool performDiffInvKin(const std::vector<double> & currentQ,

--- a/libraries/YarpPlugins/AmorCartesianControl/AmorCartesianControl.hpp
+++ b/libraries/YarpPlugins/AmorCartesianControl/AmorCartesianControl.hpp
@@ -68,6 +68,8 @@ public:
 
     virtual bool stopControl();
 
+    virtual bool wait(double timeout);
+
     virtual bool tool(const std::vector<double> &x);
 
     virtual void twist(const std::vector<double> &xdot);

--- a/libraries/YarpPlugins/AmorCartesianControl/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/AmorCartesianControl/ICartesianControlImpl.cpp
@@ -243,6 +243,13 @@ bool roboticslab::AmorCartesianControl::stopControl()
 
 // -----------------------------------------------------------------------------
 
+bool roboticslab::AmorCartesianControl::wait(double timeout)
+{
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+
 bool roboticslab::AmorCartesianControl::tool(const std::vector<double> &x)
 {
     CD_WARNING("Tool change is not supported on AMOR.\n");

--- a/libraries/YarpPlugins/AmorCartesianControl/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/AmorCartesianControl/ICartesianControlImpl.cpp
@@ -2,6 +2,7 @@
 
 #include "AmorCartesianControl.hpp"
 
+#include <yarp/os/Time.h>
 #include <yarp/os/Vocab.h>
 
 #include <ColorDebug.hpp>
@@ -102,7 +103,9 @@ bool roboticslab::AmorCartesianControl::movj(const std::vector<double> &xd)
         return false;
     }
 
-    return waitForCompletion(VOCAB_CC_MOVJ_CONTROLLING);
+    currentState = VOCAB_CC_MOVJ_CONTROLLING;
+
+    return true;
 }
 
 // -----------------------------------------------------------------------------
@@ -162,7 +165,9 @@ bool roboticslab::AmorCartesianControl::movl(const std::vector<double> &xd)
         return false;
     }
 
-    return waitForCompletion(VOCAB_CC_MOVL_CONTROLLING);
+    currentState = VOCAB_CC_MOVL_CONTROLLING;
+
+    return true;
 }
 
 // -----------------------------------------------------------------------------
@@ -245,7 +250,40 @@ bool roboticslab::AmorCartesianControl::stopControl()
 
 bool roboticslab::AmorCartesianControl::wait(double timeout)
 {
-    return true;
+    if (currentState != VOCAB_CC_MOVJ_CONTROLLING && currentState != VOCAB_CC_MOVL_CONTROLLING)
+    {
+        return true;
+    }
+
+    AMOR_RESULT res = AMOR_SUCCESS;
+    amor_movement_status status;
+
+    double start = yarp::os::Time::now();
+
+    do
+    {
+        if (timeout != 0.0 && yarp::os::Time::now() - start > timeout)
+        {
+            CD_WARNING("Timeout reached (%f seconds), stopping control.\n", timeout);
+            stopControl();
+            break;
+        }
+
+        res = amor_get_movement_status(handle, &status);
+
+        if (res == AMOR_FAILED)
+        {
+            CD_ERROR("%s\n", amor_error());
+            break;
+        }
+
+        yarp::os::Time::delay(0.5);  // seconds
+    }
+    while (status != AMOR_MOVEMENT_STATUS_FINISHED);
+
+    currentState = VOCAB_CC_NOT_CONTROLLING;
+
+    return res == AMOR_SUCCESS;
 }
 
 // -----------------------------------------------------------------------------

--- a/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
@@ -181,6 +181,7 @@ class BasicCartesianControl : public yarp::dev::DeviceDriver, public ICartesianC
 
     protected:
 
+        void handleMovj();
         void handleMovl();
         void handleMovv();
         void handleGcmp();
@@ -216,6 +217,9 @@ class BasicCartesianControl : public yarp::dev::DeviceDriver, public ICartesianC
         void setCurrentState(int value);
         mutable yarp::os::Semaphore currentStateReady;
 
+        /** MOVJ store previous reference speeds */
+        std::vector<double> vmoStored;
+
         /** MOVL keep track of movement start time to know at what time of trajectory movement we are */
         double movementStartTime;
 
@@ -227,6 +231,8 @@ class BasicCartesianControl : public yarp::dev::DeviceDriver, public ICartesianC
 
         /** FORC desired Cartesian force */
         std::vector<double> td;
+
+        bool cmcSuccess;
 };
 
 }  // namespace roboticslab

--- a/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
@@ -135,6 +135,8 @@ class BasicCartesianControl : public yarp::dev::DeviceDriver, public ICartesianC
 
         virtual bool stopControl();
 
+        virtual bool wait(double timeout);
+
         virtual bool tool(const std::vector<double> &x);
 
         virtual void twist(const std::vector<double> &xdot);

--- a/libraries/YarpPlugins/BasicCartesianControl/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/ICartesianControlImpl.cpp
@@ -319,6 +319,13 @@ bool roboticslab::BasicCartesianControl::stopControl()
 
 // -----------------------------------------------------------------------------
 
+bool roboticslab::BasicCartesianControl::wait(double timeout)
+{
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+
 bool roboticslab::BasicCartesianControl::tool(const std::vector<double> &x)
 {
     if ( ! iCartesianSolver->restoreOriginalChain() )

--- a/libraries/YarpPlugins/BasicCartesianControl/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/ICartesianControlImpl.cpp
@@ -317,7 +317,7 @@ bool roboticslab::BasicCartesianControl::wait(double timeout)
     {
         if (timeout != 0.0 && yarp::os::Time::now() - start > timeout)
         {
-            CD_WARNING("Timeout reached (%d seconds), stopping control.\n", timeout);
+            CD_WARNING("Timeout reached (%f seconds), stopping control.\n", timeout);
             stopControl();
             break;
         }

--- a/libraries/YarpPlugins/CartesianControlClient/CartesianControlClient.hpp
+++ b/libraries/YarpPlugins/CartesianControlClient/CartesianControlClient.hpp
@@ -83,6 +83,8 @@ public:
 
     virtual bool stopControl();
 
+    virtual bool wait(double timeout);
+
     virtual bool tool(const std::vector<double> &x);
 
     virtual void twist(const std::vector<double> &xdot);

--- a/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
@@ -232,7 +232,14 @@ bool roboticslab::CartesianControlClient::stopControl()
 
 bool roboticslab::CartesianControlClient::wait(double timeout)
 {
-    return true;
+    yarp::os::Bottle cmd, response;
+
+    cmd.addVocab(VOCAB_CC_WAIT);
+    cmd.addDouble(timeout);
+
+    rpcClient.write(cmd, response);
+
+    return checkSuccess(response);
 }
 
 // -----------------------------------------------------------------------------

--- a/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
@@ -230,6 +230,13 @@ bool roboticslab::CartesianControlClient::stopControl()
 
 // -----------------------------------------------------------------------------
 
+bool roboticslab::CartesianControlClient::wait(double timeout)
+{
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+
 bool roboticslab::CartesianControlClient::tool(const std::vector<double> &x)
 {
     return handleRpcConsumerCmd(VOCAB_CC_TOOL, x);

--- a/libraries/YarpPlugins/CartesianControlServer/CartesianControlServer.hpp
+++ b/libraries/YarpPlugins/CartesianControlServer/CartesianControlServer.hpp
@@ -125,6 +125,7 @@ protected:
     typedef bool (ICartesianControl::*FunctionFun)(const std::vector<double>&, std::vector<double>&);
 
     bool handleStatMsg(const yarp::os::Bottle& in, yarp::os::Bottle& out);
+    bool handleWaitMsg(const yarp::os::Bottle& in, yarp::os::Bottle& out);
 
     bool handleRunnableCmdMsg(const yarp::os::Bottle& in, yarp::os::Bottle& out, RunnableFun cmd);
     bool handleConsumerCmdMsg(const yarp::os::Bottle& in, yarp::os::Bottle& out, ConsumerFun cmd);

--- a/libraries/YarpPlugins/CartesianControlServer/RpcResponder.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/RpcResponder.cpp
@@ -91,7 +91,7 @@ void roboticslab::RpcResponder::makeUsage()
     addUsage("[gcmp]", "enable gravity compensation");
     addUsage("[forc] coord1 coord2 ...", "enable torque control, apply input forces (cartesian space)");
     addUsage("[stop]", "stop control");
-    addUsage("[wait] timeout", "wait until completion with timeout");
+    addUsage("[wait] timeout", "wait until completion with timeout (optional, 0.0 means no timeout)");
     addUsage("[tool] coord1 coord2 ...", "append fixed link to end effector");
     addUsage("[set] vocab value", "set configuration parameter");
     addUsage("[get] vocab", "get configuration parameter");

--- a/libraries/YarpPlugins/CartesianControlServer/RpcResponder.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/RpcResponder.cpp
@@ -140,25 +140,25 @@ bool roboticslab::RpcResponder::handleStatMsg(const yarp::os::Bottle& in, yarp::
 
 bool roboticslab::RpcResponder::handleWaitMsg(const yarp::os::Bottle& in, yarp::os::Bottle& out)
 {
+    bool res;
+
     if (in.size() > 1)
     {
-        double timeout = in.get(1).asDouble();
-
-        if (!iCartesianControl->wait(timeout))
-        {
-            out.addVocab(VOCAB_CC_FAILED);
-            return false;
-        }
-
-        out.addVocab(VOCAB_CC_OK);
-        return true;
+        res = iCartesianControl->wait(in.get(1).asDouble());
     }
     else
     {
-        CD_ERROR("size error\n");
+        res = iCartesianControl->wait();
+    }
+
+    if (!res)
+    {
         out.addVocab(VOCAB_CC_FAILED);
         return false;
     }
+
+    out.addVocab(VOCAB_CC_OK);
+    return true;
 }
 
 // -----------------------------------------------------------------------------

--- a/libraries/YarpPlugins/CartesianControlServer/RpcResponder.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/RpcResponder.cpp
@@ -144,7 +144,8 @@ bool roboticslab::RpcResponder::handleWaitMsg(const yarp::os::Bottle& in, yarp::
 
     if (in.size() > 1)
     {
-        res = iCartesianControl->wait(in.get(1).asDouble());
+        double timeout = in.get(1).asDouble();
+        res = iCartesianControl->wait(timeout);
     }
     else
     {

--- a/libraries/YarpPlugins/CartesianControlServer/RpcResponder.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/RpcResponder.cpp
@@ -65,6 +65,8 @@ bool roboticslab::RpcResponder::respond(const yarp::os::Bottle& in, yarp::os::Bo
         return handleConsumerCmdMsg(in, out, &ICartesianControl::forc);
     case VOCAB_CC_STOP:
         return handleRunnableCmdMsg(in, out, &ICartesianControl::stopControl);
+    case VOCAB_CC_WAIT:
+        return handleWaitMsg(in, out);
     case VOCAB_CC_TOOL:
         return handleConsumerCmdMsg(in, out, &ICartesianControl::tool);
     case VOCAB_CC_SET:
@@ -89,6 +91,7 @@ void roboticslab::RpcResponder::makeUsage()
     addUsage("[gcmp]", "enable gravity compensation");
     addUsage("[forc] coord1 coord2 ...", "enable torque control, apply input forces (cartesian space)");
     addUsage("[stop]", "stop control");
+    addUsage("[wait] timeout", "wait until completion with timeout");
     addUsage("[tool] coord1 coord2 ...", "append fixed link to end effector");
     addUsage("[set] vocab value", "set configuration parameter");
     addUsage("[get] vocab", "get configuration parameter");
@@ -128,6 +131,31 @@ bool roboticslab::RpcResponder::handleStatMsg(const yarp::os::Bottle& in, yarp::
     }
     else
     {
+        out.addVocab(VOCAB_CC_FAILED);
+        return false;
+    }
+}
+
+// -----------------------------------------------------------------------------
+
+bool roboticslab::RpcResponder::handleWaitMsg(const yarp::os::Bottle& in, yarp::os::Bottle& out)
+{
+    if (in.size() > 1)
+    {
+        double timeout = in.get(1).asDouble();
+
+        if (!iCartesianControl->wait(timeout))
+        {
+            out.addVocab(VOCAB_CC_FAILED);
+            return false;
+        }
+
+        out.addVocab(VOCAB_CC_OK);
+        return true;
+    }
+    else
+    {
+        CD_ERROR("size error\n");
         out.addVocab(VOCAB_CC_FAILED);
         return false;
     }

--- a/libraries/YarpPlugins/ICartesianControl.h
+++ b/libraries/YarpPlugins/ICartesianControl.h
@@ -54,6 +54,7 @@
 #define VOCAB_CC_GCMP VOCAB4('g','c','m','p') ///< Gravity compensation
 #define VOCAB_CC_FORC VOCAB4('f','o','r','c') ///< Force control
 #define VOCAB_CC_STOP VOCAB4('s','t','o','p') ///< Stop control
+#define VOCAB_CC_WAIT VOCAB4('w','a','i','t') ///< Wait motion done
 #define VOCAB_CC_TOOL VOCAB4('t','o','o','l') ///< Change tool
 
 /** @} */
@@ -255,6 +256,19 @@ class ICartesianControl
          * @return true on success, false otherwise
          */
         virtual bool stopControl() = 0;
+
+        /**
+         * @brief Wait until completion
+         *
+         * Block execution until the movement is completed, errors occur or timeout
+         * is reached.
+         *
+         * @param timeout Timeout in seconds.
+         *
+         * @return true on success, false if errors occurred during the execution
+         * of the trajectory
+         */
+        virtual bool wait(double timeout) = 0;
 
         /**
          * @brief Change tool

--- a/libraries/YarpPlugins/ICartesianControl.h
+++ b/libraries/YarpPlugins/ICartesianControl.h
@@ -263,12 +263,12 @@ class ICartesianControl
          * Block execution until the movement is completed, errors occur or timeout
          * is reached.
          *
-         * @param timeout Timeout in seconds.
+         * @param timeout Timeout in seconds, '0.0' means no timeout.
          *
          * @return true on success, false if errors occurred during the execution
          * of the trajectory
          */
-        virtual bool wait(double timeout) = 0;
+        virtual bool wait(double timeout = 0.0) = 0;
 
         /**
          * @brief Change tool


### PR DESCRIPTION
Fixes #106.

New addition: `ICartesianControl::wait` command (RPC).

Usage:

* only meant for implementations of `movj` (`relj`) and `movl`, returns immediately otherwise
* blocks until the movement completes or the specified time (in seconds) has elapsed 
* `0.0` or a missing timeout value (C++ optional parameter) means no timeout:
   https://github.com/roboticslab-uc3m/kinematics-dynamics/blob/7ab706f6279fa77f76be5091d41831ee9b31f186/libraries/YarpPlugins/ICartesianControl.h#L271
* returns `true` or `false` if errors occurred during the execution of the movement (e.g. maximum joint velocity hit, cannot query current motion status)

Notes:

* not sure about making the `timeout` parameter optional
* no (safety) check for negative values (but would stop control straight away, see implementation)
* [`yarp::dev::ICartesianControl::waitMotionDone`](http://www.yarp.it/classyarp_1_1dev_1_1ICartesianControl.html#af1a253cb67ed5cf091854a58248e6446) goes a bit further and introduces the check time period parameter (right now hardcoded to 0.5 seconds)