### PR TITLE
Adopt rectangular velocity profiles in BasicCartesianControl::movv

### DIFF
--- a/libraries/TrajectoryLib/ICartesianTrajectory.hpp
+++ b/libraries/TrajectoryLib/ICartesianTrajectory.hpp
@@ -25,7 +25,8 @@ public:
     //! Lists available Cartesian velocity profiles.
     enum cartesian_velocity_profile
     {
-        TRAPEZOIDAL        ///< A trapezoidal velocity profile
+        TRAPEZOIDAL,        ///< A trapezoidal velocity profile
+        RECTANGULAR         ///< A rectangular velocity profile
     };
 
     /**

--- a/libraries/TrajectoryLib/KdlTrajectory.cpp
+++ b/libraries/TrajectoryLib/KdlTrajectory.cpp
@@ -9,6 +9,7 @@
 #include <kdl/rotational_interpolation_sa.hpp>
 #include <kdl/velocityprofile_trap.hpp>
 #include <kdl/velocityprofile_rect.hpp>
+#include <kdl/utilities/error.h>
 
 #include <ColorDebug.h>
 
@@ -50,18 +51,34 @@ bool roboticslab::KdlTrajectory::getPosition(const double movementTime, std::vec
 
 bool roboticslab::KdlTrajectory::getVelocity(const double movementTime, std::vector<double>& velocity)
 {
-    KDL::Twist xdotFrame = currentTrajectory->Vel(movementTime);
-    velocity = KdlVectorConverter::twistToVector(xdotFrame);
-    return true;
+    try
+    {
+        KDL::Twist xdotFrame = currentTrajectory->Vel(movementTime);
+        velocity = KdlVectorConverter::twistToVector(xdotFrame);
+        return true;
+    }
+    catch (const KDL::Error_MotionPlanning &e)
+    {
+        CD_ERROR("Unable to retrieve velocity at %f.\n", movementTime);
+        return false;
+    }
 }
 
 // -----------------------------------------------------------------------------
 
 bool roboticslab::KdlTrajectory::getAcceleration(const double movementTime, std::vector<double>& acceleration)
 {
-    KDL::Twist xdotdotFrame = currentTrajectory->Acc(movementTime);
-    acceleration = KdlVectorConverter::twistToVector(xdotdotFrame);
-    return true;
+    try
+    {
+        KDL::Twist xdotdotFrame = currentTrajectory->Acc(movementTime);
+        acceleration = KdlVectorConverter::twistToVector(xdotdotFrame);
+        return true;
+    }
+    catch (const KDL::Error_MotionPlanning &e)
+    {
+        CD_ERROR("Unable to retrieve acceleration at %f.\n", movementTime);
+        return false;
+    }
 }
 
 // -----------------------------------------------------------------------------

--- a/libraries/TrajectoryLib/KdlTrajectory.cpp
+++ b/libraries/TrajectoryLib/KdlTrajectory.cpp
@@ -126,7 +126,7 @@ bool roboticslab::KdlTrajectory::configurePath(const int pathType)
     {
     case ICartesianTrajectory::LINE:
     {
-        if ( frames.empty() || frames.size() > 2 )
+        if ( frames.empty() || frames.size() > 2 || ( frames.size() == 1 && twists.empty() ) )
         {
             CD_ERROR("Need 2 waypoints (or 1 with initial twist) for Cartesian line (have %d)!\n", frames.size());
             return false;

--- a/libraries/TrajectoryLib/KdlTrajectory.cpp
+++ b/libraries/TrajectoryLib/KdlTrajectory.cpp
@@ -42,9 +42,17 @@ bool roboticslab::KdlTrajectory::getDuration(double* duration) const
 
 bool roboticslab::KdlTrajectory::getPosition(const double movementTime, std::vector<double>& position)
 {
-    KDL::Frame xFrame = currentTrajectory->Pos(movementTime);
-    position = KdlVectorConverter::frameToVector(xFrame);
-    return true;
+    try
+    {
+        const KDL::Frame & xFrame = currentTrajectory->Pos(movementTime);
+        position = KdlVectorConverter::frameToVector(xFrame);
+        return true;
+    }
+    catch (const KDL::Error_MotionPlanning &e)
+    {
+        CD_ERROR("Unable to retrieve position at %f.\n", movementTime);
+        return false;
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -53,7 +61,7 @@ bool roboticslab::KdlTrajectory::getVelocity(const double movementTime, std::vec
 {
     try
     {
-        KDL::Twist xdotFrame = currentTrajectory->Vel(movementTime);
+        const KDL::Twist & xdotFrame = currentTrajectory->Vel(movementTime);
         velocity = KdlVectorConverter::twistToVector(xdotFrame);
         return true;
     }
@@ -70,7 +78,7 @@ bool roboticslab::KdlTrajectory::getAcceleration(const double movementTime, std:
 {
     try
     {
-        KDL::Twist xdotdotFrame = currentTrajectory->Acc(movementTime);
+        const KDL::Twist & xdotdotFrame = currentTrajectory->Acc(movementTime);
         acceleration = KdlVectorConverter::twistToVector(xdotdotFrame);
         return true;
     }

--- a/libraries/TrajectoryLib/KdlTrajectory.cpp
+++ b/libraries/TrajectoryLib/KdlTrajectory.cpp
@@ -131,11 +131,6 @@ bool roboticslab::KdlTrajectory::configureVelocityProfile(const int velocityProf
 
 bool roboticslab::KdlTrajectory::create()
 {
-    if( DURATION_NOT_SET == duration )
-    {
-        CD_ERROR("Duration not set!\n");
-        return false;
-    }
     if( ! configuredPath )
     {
         CD_ERROR("Path not configured!\n");
@@ -147,7 +142,16 @@ bool roboticslab::KdlTrajectory::create()
         return false;
     }
 
-    currentTrajectory = new KDL::Trajectory_Segment(path, velocityProfile, duration);
+    if( duration == DURATION_NOT_SET )
+    {
+        velocityProfile->SetProfile(0, path->PathLength());
+        currentTrajectory = new KDL::Trajectory_Segment(path, velocityProfile);
+    }
+    else
+    {
+        // velocity profile is set under the hood
+        currentTrajectory = new KDL::Trajectory_Segment(path, velocityProfile, duration);
+    }
 
     return true;
 }

--- a/libraries/TrajectoryLib/KdlTrajectory.cpp
+++ b/libraries/TrajectoryLib/KdlTrajectory.cpp
@@ -16,21 +16,23 @@
 
 // -----------------------------------------------------------------------------
 
-// In C++11, declare starting with with std::numeric_limits<int>::min()
+// In C++11, declare enum starting with std::numeric_limits<int>::min()
 // https://stackoverflow.com/a/21027383
 const int roboticslab::KdlTrajectory::DURATION_NOT_SET = -1;
 const int roboticslab::KdlTrajectory::DURATION_INFINITE = -2;
 
 // -----------------------------------------------------------------------------
 
-roboticslab::KdlTrajectory::KdlTrajectory()
-    : currentTrajectory(0),
+roboticslab::KdlTrajectory::KdlTrajectory(double maxVelocity, double maxAcceleration)
+    : duration(DURATION_NOT_SET),
+      maxVelocity(maxVelocity),
+      maxAcceleration(maxAcceleration),
+      configuredPath(false),
+      configuredVelocityProfile(false),
+      currentTrajectory(0),
       path(0),
       orient(0),
-      velocityProfile(0),
-      duration(DURATION_NOT_SET),
-      configuredPath(false),
-      configuredVelocityProfile(false)
+      velocityProfile(0)
 {}
 
 // -----------------------------------------------------------------------------
@@ -143,12 +145,12 @@ bool roboticslab::KdlTrajectory::configureVelocityProfile(const int velocityProf
     {
     case ICartesianTrajectory::TRAPEZOIDAL:
     {
-        velocityProfile = new KDL::VelocityProfile_Trap(DEFAULT_CARTESIAN_MAX_VEL, DEFAULT_CARTESIAN_MAX_ACC);
+        velocityProfile = new KDL::VelocityProfile_Trap(maxVelocity, maxAcceleration);
         break;
     }
     case ICartesianTrajectory::RECTANGULAR:
     {
-        velocityProfile = new KDL::VelocityProfile_Rectangular(DEFAULT_CARTESIAN_MAX_VEL);
+        velocityProfile = new KDL::VelocityProfile_Rectangular(maxVelocity);
         break;
     }
     default:

--- a/libraries/TrajectoryLib/KdlTrajectory.hpp
+++ b/libraries/TrajectoryLib/KdlTrajectory.hpp
@@ -143,7 +143,7 @@ public:
 private:
 
     double duration;
-    double maxVelocity, maxAcceleration;
+    const double maxVelocity, maxAcceleration;
 
     bool configuredPath, configuredVelocityProfile;
     bool velocityDrivenPath;

--- a/libraries/TrajectoryLib/KdlTrajectory.hpp
+++ b/libraries/TrajectoryLib/KdlTrajectory.hpp
@@ -13,6 +13,8 @@
 
 #include "ICartesianTrajectory.hpp"
 
+#define DURATION_NOT_SET -1
+
 #define DEFAULT_CARTESIAN_MAX_VEL 7.5      // unit/s, enforces a min duration of KDL::Trajectory_Segment
 #define DEFAULT_CARTESIAN_MAX_ACC 0.2      // unit/s^2
 
@@ -138,21 +140,19 @@ public:
      */
     virtual bool destroy();
 
-    /** @brief Denotes that the trajectory duration was not set */
-    static const int DURATION_NOT_SET;
-
-    /** @brief Denotes an infinite trajectory duration */
-    static const int DURATION_INFINITE;
-
 private:
 
     double duration;
     double maxVelocity, maxAcceleration;
+
     bool configuredPath, configuredVelocityProfile;
+    bool velocityDrivenPath;
+
     KDL::Trajectory* currentTrajectory;
     KDL::Path* path;
     KDL::RotationalInterpolation* orient;
     KDL::VelocityProfile * velocityProfile;
+
     std::vector<KDL::Frame> frames;
     std::vector<KDL::Twist> twists;
 };

--- a/libraries/TrajectoryLib/KdlTrajectory.hpp
+++ b/libraries/TrajectoryLib/KdlTrajectory.hpp
@@ -3,7 +3,6 @@
 #ifndef __KDL_TRAJECTORY_HPP__
 #define __KDL_TRAJECTORY_HPP__
 
-#include <string>
 #include <vector>
 
 #include <kdl/frames.hpp>
@@ -14,7 +13,6 @@
 
 #include "ICartesianTrajectory.hpp"
 
-#define DURATION_NOT_SET -1
 #define DEFAULT_CARTESIAN_MAX_VEL 7.5      // unit/s, enforces a min duration of KDL::Trajectory_Segment
 #define DEFAULT_CARTESIAN_MAX_ACC 0.2      // unit/s^2
 
@@ -134,6 +132,12 @@ public:
      */
     virtual bool destroy();
 
+    /** @brief Denotes that the trajectory duration was not set */
+    static const int DURATION_NOT_SET;
+
+    /** @brief Denotes an infinite trajectory duration */
+    static const int DURATION_INFINITE;
+
 private:
 
     double duration;
@@ -143,7 +147,7 @@ private:
     KDL::RotationalInterpolation* orient;
     KDL::VelocityProfile * velocityProfile;
     std::vector<KDL::Frame> frames;
-
+    std::vector<KDL::Twist> twists;
 };
 
 }  // namespace roboticslab

--- a/libraries/TrajectoryLib/KdlTrajectory.hpp
+++ b/libraries/TrajectoryLib/KdlTrajectory.hpp
@@ -27,7 +27,13 @@ class KdlTrajectory : public ICartesianTrajectory
 {
 public:
 
-    KdlTrajectory();
+    /**
+     * @brief Constructor
+     *
+     * @param maxVelocity Maximum allowed path velocity (meters/second)
+     * @param maxAcceleration Maximum allowed path acceleration (meters/second^2)
+     */
+    KdlTrajectory(double maxVelocity = DEFAULT_CARTESIAN_MAX_VEL, double maxAcceleration = DEFAULT_CARTESIAN_MAX_ACC);
 
     /**
      * @brief Get trajectory total duration in seconds
@@ -141,6 +147,7 @@ public:
 private:
 
     double duration;
+    double maxVelocity, maxAcceleration;
     bool configuredPath, configuredVelocityProfile;
     KDL::Trajectory* currentTrajectory;
     KDL::Path* path;

--- a/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
@@ -247,9 +247,6 @@ class BasicCartesianControl : public yarp::dev::DeviceDriver, public ICartesianC
         /** MOVL store Cartesian trajectory */
         ICartesianTrajectory* iCartesianTrajectory;
 
-        /** MOVV desired Cartesian velocity */
-        std::vector<double> xdotd;
-
         /** FORC desired Cartesian force */
         std::vector<double> td;
 

--- a/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
@@ -237,6 +237,7 @@ class BasicCartesianControl : public yarp::dev::DeviceDriver, public ICartesianC
         int getCurrentState() const;
         void setCurrentState(int value);
         mutable yarp::os::Semaphore currentStateReady;
+        mutable yarp::os::Semaphore trajectoryMutex;
 
         /** MOVJ store previous reference speeds */
         std::vector<double> vmoStored;

--- a/libraries/YarpPlugins/BasicCartesianControl/DeviceDriverImpl.cpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/DeviceDriverImpl.cpp
@@ -126,6 +126,7 @@ bool roboticslab::BasicCartesianControl::open(yarp::os::Searchable& config)
 
 bool roboticslab::BasicCartesianControl::close()
 {
+    stopControl();
     yarp::os::RateThread::stop();
     robotDevice.close();
     solverDevice.close();

--- a/libraries/YarpPlugins/BasicCartesianControl/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/ICartesianControlImpl.cpp
@@ -240,15 +240,65 @@ bool roboticslab::BasicCartesianControl::movl(const std::vector<double> &xd)
 
 bool roboticslab::BasicCartesianControl::movv(const std::vector<double> &xdotd)
 {
+    std::vector<double> currentQ(numRobotJoints);
+    if ( ! iEncoders->getEncoders( currentQ.data() ) )
+    {
+        CD_ERROR("getEncoders failed.\n");
+        return false;
+    }
+
+    std::vector<double> x_base_tcp;
+    if ( ! iCartesianSolver->fwdKin(currentQ,x_base_tcp) )
+    {
+        CD_ERROR("fwdKin failed.\n");
+        return false;
+    }
+
+    if ( iCartesianTrajectory == NULL || getCurrentState() != VOCAB_CC_MOVV_CONTROLLING )
+    {
+        //-- Create line trajectory if not already controlling
+        iCartesianTrajectory = new KdlTrajectory;
+    }
+    else
+    {
+        iCartesianTrajectory->destroy();
+    }
+    if( ! iCartesianTrajectory->addWaypoint(x_base_tcp, xdotd) )
+    {
+        CD_ERROR("\n");
+        return false;
+    }
+    if( ! iCartesianTrajectory->configurePath( ICartesianTrajectory::LINE ) )
+    {
+        CD_ERROR("\n");
+        return false;
+    }
+    if( ! iCartesianTrajectory->configureVelocityProfile( ICartesianTrajectory::RECTANGULAR ) )
+    {
+        CD_ERROR("\n");
+        return false;
+    }
+    if( ! iCartesianTrajectory->create() )
+    {
+        CD_ERROR("\n");
+        return false;
+    }
+
     //-- Set velocity mode and set state which makes rate thread implement control.
-    this->xdotd = xdotd;
     std::vector<int> velModes(numRobotJoints, VOCAB_CM_VELOCITY);
     if (!iControlMode->setControlModes(velModes.data()))
     {
         CD_ERROR("setControlModes failed.\n");
         return false;
     }
+
+    //-- Set state, enable CMC thread and wait for movement to be done
+    movementStartTime = yarp::os::Time::now();
+    cmcSuccess = true;
+    CD_SUCCESS("Waiting\n");
+
     setCurrentState( VOCAB_CC_MOVV_CONTROLLING );
+
     return true;
 }
 

--- a/libraries/YarpPlugins/BasicCartesianControl/RateThreadImpl.cpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/RateThreadImpl.cpp
@@ -198,6 +198,8 @@ void roboticslab::BasicCartesianControl::handleMovl()
 
 void roboticslab::BasicCartesianControl::handleMovv()
 {
+    double movementTime = yarp::os::Time::now() - movementStartTime;
+
     //-- Obtain current joint position
     std::vector<double> currentQ(numRobotJoints);
 
@@ -207,20 +209,43 @@ void roboticslab::BasicCartesianControl::handleMovv()
         return;
     }
 
+    std::vector<double> currentX;
+
+    if (!iCartesianSolver->fwdKin(currentQ, currentX))
+    {
+        CD_WARNING("fwdKin failed, not updating control this iteration.\n");
+        return;
+    }
+
+    //-- Obtain desired Cartesian position and velocity.
+    std::vector<double> desiredX, desiredXdot;
+    iCartesianTrajectory->getPosition(movementTime, desiredX);
+    iCartesianTrajectory->getVelocity(movementTime, desiredXdot);
+
+    //-- Apply control law to compute robot Cartesian velocity commands.
+    std::vector<double> commandXdot;
+    iCartesianSolver->poseDiff(desiredX, currentX, commandXdot);
+
+    for (int i = 0; i < 6; i++)
+    {
+        commandXdot[i] *= gain * (1000.0 / cmcRateMs);
+        commandXdot[i] += desiredXdot[i];
+    }
+
     //-- Compute joint velocity commands and send to robot.
     std::vector<double> commandQdot;
 
-    if (!iCartesianSolver->diffInvKin(currentQ, xdotd, commandQdot, referenceFrame))
+    if (!iCartesianSolver->diffInvKin(currentQ, commandXdot, commandQdot, referenceFrame))
     {
         CD_WARNING("diffInvKin failed, not updating control this iteration.\n");
         return;
     }
 
-    CD_DEBUG_NO_HEADER("[MOVV] ");
+    CD_DEBUG_NO_HEADER("[MOVV] [%f] ", movementTime);
 
     for (int i = 0; i < 6; i++)
     {
-        CD_DEBUG_NO_HEADER("%f ", xdotd[i]);
+        CD_DEBUG_NO_HEADER("%f ", commandXdot[i]);
     }
 
     CD_DEBUG_NO_HEADER("-> ");
@@ -237,6 +262,7 @@ void roboticslab::BasicCartesianControl::handleMovv()
         if (std::abs(commandQdot[i]) > maxJointVelocity)
         {
             CD_ERROR("diffInvKin too dangerous, STOP!!!\n");
+            cmcSuccess = false;
             stopControl();
             return;
         }

--- a/libraries/YarpPlugins/BasicCartesianControl/RateThreadImpl.cpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/RateThreadImpl.cpp
@@ -219,8 +219,11 @@ void roboticslab::BasicCartesianControl::handleMovv()
 
     //-- Obtain desired Cartesian position and velocity.
     std::vector<double> desiredX, desiredXdot;
+
+    trajectoryMutex.wait();
     iCartesianTrajectory->getPosition(movementTime, desiredX);
     iCartesianTrajectory->getVelocity(movementTime, desiredXdot);
+    trajectoryMutex.post();
 
     //-- Apply control law to compute robot Cartesian velocity commands.
     std::vector<double> commandXdot;

--- a/tests/testKdlTrajectory.cpp
+++ b/tests/testKdlTrajectory.cpp
@@ -151,8 +151,7 @@ TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRect)
     ASSERT_NEAR(position[0], x1[0] + (x2[0] - x1[0]) * (movementTime / duration), EPS);
     ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
     ASSERT_NEAR(velocity[0], (x2[0] - x1[0]) / duration, EPS);
-    //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
-    //ASSERT_NEAR(acceleration[0], MAX_ACC, eps);
+    ASSERT_FALSE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
 
     //-- Destroy line
     ASSERT_TRUE(iCartesianTrajectory->destroy());
@@ -180,8 +179,7 @@ TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRectNoDuration)
     ASSERT_NEAR(position[0], x1[0] + MAX_VEL * movementTime, EPS);
     ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
     ASSERT_NEAR(velocity[0], MAX_VEL, EPS);
-    //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
-    //ASSERT_NEAR(acceleration[0], MAX_ACC, eps);
+    ASSERT_FALSE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
 
     //-- Destroy line
     ASSERT_TRUE(iCartesianTrajectory->destroy());
@@ -209,8 +207,7 @@ TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRectInitialTwist)
     ASSERT_NEAR(position[0], x1[0] + v1[0] * movementTime, EPS);
     ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
     ASSERT_NEAR(velocity[0], v1[0], EPS);
-    //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
-    //ASSERT_NEAR(acceleration[0], MAX_ACC, eps);
+    ASSERT_FALSE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
 
     //-- Destroy line
     ASSERT_TRUE(iCartesianTrajectory->destroy());
@@ -232,8 +229,7 @@ TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRectInitialTwistNoDuration)
     ASSERT_NEAR(position[0], x1[0] + v1[0] * movementTime, EPS);
     ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
     ASSERT_NEAR(velocity[0], v1[0], EPS);
-    //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
-    //ASSERT_NEAR(acceleration[0], MAX_ACC, eps);
+    ASSERT_FALSE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
 
     //-- Destroy line
     ASSERT_TRUE(iCartesianTrajectory->destroy());
@@ -255,8 +251,7 @@ TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRectInitialTwistNoDurationCapped)
     ASSERT_NEAR(position[0], x1[0] + MAX_VEL * movementTime, EPS);
     ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
     ASSERT_NEAR(velocity[0], MAX_VEL, EPS);
-    //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
-    //ASSERT_NEAR(acceleration[0], MAX_ACC, eps);
+    ASSERT_FALSE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
 
     //-- Destroy line
     ASSERT_TRUE(iCartesianTrajectory->destroy());

--- a/tests/testKdlTrajectory.cpp
+++ b/tests/testKdlTrajectory.cpp
@@ -97,14 +97,16 @@ TEST_F(KdlTrajectoryTest, KdlTrajectoryLineTrapNoDuration)
     double movementTime;
     std::vector<double> position, velocity, acceleration;
 
+    // ramp up
     movementTime = 2.0;
     ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
     ASSERT_NEAR(position[0], x1[0] + 0.1, EPS);
     ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
-    ASSERT_NEAR(velocity[0], 0.1, EPS);
+    ASSERT_NEAR(velocity[0], MAX_ACC * movementTime, EPS);
     ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
     ASSERT_NEAR(acceleration[0], MAX_ACC, EPS);
 
+    // steady
     movementTime = 4.5;
     ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
     ASSERT_NEAR(position[0], x1[0] + 0.5, EPS);
@@ -113,11 +115,12 @@ TEST_F(KdlTrajectoryTest, KdlTrajectoryLineTrapNoDuration)
     ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
     ASSERT_NEAR(acceleration[0], 0.0, EPS);
 
+    // ramp down
     movementTime = 7.0;
     ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
     ASSERT_NEAR(position[0], x1[0] + 0.9, EPS);
     ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
-    ASSERT_NEAR(velocity[0], 0.1, EPS);
+    ASSERT_NEAR(velocity[0], MAX_ACC * (duration - movementTime), EPS);
     ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
     ASSERT_NEAR(acceleration[0], -MAX_ACC, EPS);
 
@@ -145,9 +148,9 @@ TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRect)
     std::vector<double> position, velocity, acceleration;
 
     ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
-    ASSERT_NEAR(position[0], x1[0] + 0.5, EPS);
+    ASSERT_NEAR(position[0], x1[0] + (x2[0] - x1[0]) * (movementTime / duration), EPS);
     ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
-    ASSERT_NEAR(velocity[0], 0.1, EPS);
+    ASSERT_NEAR(velocity[0], (x2[0] - x1[0]) / duration, EPS);
     //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
     //ASSERT_NEAR(acceleration[0], MAX_ACC, eps);
 
@@ -174,7 +177,7 @@ TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRectNoDuration)
     std::vector<double> position, velocity, acceleration;
 
     ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
-    ASSERT_NEAR(position[0], x1[0] + 0.4, EPS);
+    ASSERT_NEAR(position[0], x1[0] + MAX_VEL * movementTime, EPS);
     ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
     ASSERT_NEAR(velocity[0], MAX_VEL, EPS);
     //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
@@ -203,7 +206,7 @@ TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRectInitialTwist)
     std::vector<double> position, velocity, acceleration;
 
     ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
-    ASSERT_NEAR(position[0], x1[0] + 0.5, EPS);
+    ASSERT_NEAR(position[0], x1[0] + v1[0] * movementTime, EPS);
     ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
     ASSERT_NEAR(velocity[0], v1[0], EPS);
     //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
@@ -226,7 +229,7 @@ TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRectInitialTwistNoDuration)
     std::vector<double> position, velocity, acceleration;
 
     ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
-    ASSERT_NEAR(position[0], x1[0] + 0.5, EPS);
+    ASSERT_NEAR(position[0], x1[0] + v1[0] * movementTime, EPS);
     ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
     ASSERT_NEAR(velocity[0], v1[0], EPS);
     //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
@@ -249,7 +252,7 @@ TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRectInitialTwistNoDurationCapped)
     std::vector<double> position, velocity, acceleration;
 
     ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
-    ASSERT_NEAR(position[0], x1[0] + 1.0, EPS);
+    ASSERT_NEAR(position[0], x1[0] + MAX_VEL * movementTime, EPS);
     ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
     ASSERT_NEAR(velocity[0], MAX_VEL, EPS);
     //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));

--- a/tests/testKdlTrajectory.cpp
+++ b/tests/testKdlTrajectory.cpp
@@ -16,7 +16,17 @@ class KdlTrajectoryTest : public testing::Test
 public:
     virtual void SetUp()
     {
-        iCartesianTrajectory = new KdlTrajectory;
+        iCartesianTrajectory = new KdlTrajectory(MAX_VEL, MAX_ACC);
+
+        x1.resize(6);
+        x2.resize(6);
+        v1.resize(6);
+        v1_alt.resize(6);
+
+        x1[0] = 1.0;
+        x2[0] = 2.0;
+        v1[0] = 0.1;
+        v1_alt[0] = 0.5;
     }
 
     virtual void TearDown()
@@ -27,39 +37,226 @@ public:
 
 protected:
     ICartesianTrajectory* iCartesianTrajectory;
+
+    std::vector<double> x1, x2, v1, v1_alt;
+
+    static const double MAX_VEL;
+    static const double MAX_ACC;
+
+    static const double EPS;
 };
 
-TEST_F(KdlTrajectoryTest, KdlTrajectoryLine)
-{
-    //-- Create line trajectory
-    ASSERT_TRUE( iCartesianTrajectory->setDuration(20.0) );  // Must be high, or may be expanded due to defaults
-    std::vector<double> x(6);
-    x[0] = 0;  // x
-    x[1] = 0;  // y
-    x[2] = 0;  // z
-    x[3] = 0;  // o(x)
-    x[4] = 0;  // o(y)
-    x[5] = 0;  // o(z)
-    std::vector<double> xd(6);
-    xd[0] = 1;  // x
-    xd[1] = 0;  // y
-    xd[2] = 0;  // z
-    xd[3] = 0;  // o(x)
-    xd[4] = 0;  // o(y)
-    xd[5] = 0;  // o(z)
-    ASSERT_TRUE( iCartesianTrajectory->addWaypoint(x) );
-    ASSERT_TRUE( iCartesianTrajectory->addWaypoint(xd) );
-    ASSERT_TRUE( iCartesianTrajectory->configurePath( ICartesianTrajectory::LINE ) );
-    ASSERT_TRUE( iCartesianTrajectory->configureVelocityProfile( ICartesianTrajectory::TRAPEZOIDAL ) );
-    ASSERT_TRUE( iCartesianTrajectory->create() );
+const double KdlTrajectoryTest::MAX_VEL = 0.2;
+const double KdlTrajectoryTest::MAX_ACC = 0.05;
 
-    //-- Use line
-    double duration;
-    ASSERT_TRUE( iCartesianTrajectory->getDuration(&duration) );
-    ASSERT_EQ(duration, 20.0);
+const double KdlTrajectoryTest::EPS = 1e-9;
+
+TEST_F(KdlTrajectoryTest, KdlTrajectoryCreate)
+{
+    //-- Create dummy trajectory, no path nor velocity profile set
+    ASSERT_FALSE(iCartesianTrajectory->create());
 
     //-- Destroy line
-    ASSERT_TRUE( iCartesianTrajectory->destroy() );
+    ASSERT_TRUE(iCartesianTrajectory->destroy());
+}
+
+TEST_F(KdlTrajectoryTest, KdlTrajectoryLineTrap)
+{
+    //-- Create line trajectory
+    ASSERT_TRUE(iCartesianTrajectory->setDuration(10.0)); // Must be higher than 9.0 due to defaults
+    ASSERT_TRUE(iCartesianTrajectory->addWaypoint(x1));
+    ASSERT_TRUE(iCartesianTrajectory->addWaypoint(x2));
+    ASSERT_TRUE(iCartesianTrajectory->configurePath(ICartesianTrajectory::LINE));
+    ASSERT_TRUE(iCartesianTrajectory->configureVelocityProfile(ICartesianTrajectory::TRAPEZOIDAL));
+    ASSERT_TRUE(iCartesianTrajectory->create());
+
+    //-- Query duration, should be the same as set before
+    double duration;
+    ASSERT_TRUE(iCartesianTrajectory->getDuration(&duration));
+    ASSERT_EQ(duration, 10.0);
+
+    //-- Destroy line
+    ASSERT_TRUE(iCartesianTrajectory->destroy());
+}
+
+TEST_F(KdlTrajectoryTest, KdlTrajectoryLineTrapNoDuration)
+{
+    //-- Create line trajectory
+    ASSERT_TRUE(iCartesianTrajectory->addWaypoint(x1));
+    ASSERT_TRUE(iCartesianTrajectory->addWaypoint(x2));
+    ASSERT_TRUE(iCartesianTrajectory->configurePath(ICartesianTrajectory::LINE));
+    ASSERT_TRUE(iCartesianTrajectory->configureVelocityProfile(ICartesianTrajectory::TRAPEZOIDAL));
+    ASSERT_TRUE(iCartesianTrajectory->create());
+
+    //-- Query duration according to a trapezoidal velocity profile
+    double duration;
+    ASSERT_TRUE(iCartesianTrajectory->getDuration(&duration));
+    ASSERT_NEAR(duration, 9.0, EPS);
+
+    //-- Use line
+    double movementTime;
+    std::vector<double> position, velocity, acceleration;
+
+    movementTime = 2.0;
+    ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
+    ASSERT_NEAR(position[0], x1[0] + 0.1, EPS);
+    ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
+    ASSERT_NEAR(velocity[0], 0.1, EPS);
+    ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
+    ASSERT_NEAR(acceleration[0], MAX_ACC, EPS);
+
+    movementTime = 4.5;
+    ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
+    ASSERT_NEAR(position[0], x1[0] + 0.5, EPS);
+    ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
+    ASSERT_NEAR(velocity[0], MAX_VEL, EPS);
+    ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
+    ASSERT_NEAR(acceleration[0], 0.0, EPS);
+
+    movementTime = 7.0;
+    ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
+    ASSERT_NEAR(position[0], x1[0] + 0.9, EPS);
+    ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
+    ASSERT_NEAR(velocity[0], 0.1, EPS);
+    ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
+    ASSERT_NEAR(acceleration[0], -MAX_ACC, EPS);
+
+    //-- Destroy line
+    ASSERT_TRUE(iCartesianTrajectory->destroy());
+}
+
+TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRect)
+{
+    //-- Create line trajectory
+    ASSERT_TRUE(iCartesianTrajectory->setDuration(10.0)); // Short duration means higher vel, beware of default limit
+    ASSERT_TRUE(iCartesianTrajectory->addWaypoint(x1));
+    ASSERT_TRUE(iCartesianTrajectory->addWaypoint(x2));
+    ASSERT_TRUE(iCartesianTrajectory->configurePath(ICartesianTrajectory::LINE));
+    ASSERT_TRUE(iCartesianTrajectory->configureVelocityProfile(ICartesianTrajectory::RECTANGULAR));
+    ASSERT_TRUE(iCartesianTrajectory->create());
+
+    //-- Query duration, should be the same as set before
+    double duration;
+    ASSERT_TRUE(iCartesianTrajectory->getDuration(&duration));
+    ASSERT_NEAR(duration, 10.0, EPS);
+
+    //-- Use line
+    double movementTime = 5.0;
+    std::vector<double> position, velocity, acceleration;
+
+    ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
+    ASSERT_NEAR(position[0], x1[0] + 0.5, EPS);
+    ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
+    ASSERT_NEAR(velocity[0], 0.1, EPS);
+    //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
+    //ASSERT_NEAR(acceleration[0], MAX_ACC, eps);
+
+    //-- Destroy line
+    ASSERT_TRUE(iCartesianTrajectory->destroy());
+}
+
+TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRectNoDuration)
+{
+    //-- Create line trajectory
+    ASSERT_TRUE(iCartesianTrajectory->addWaypoint(x1));
+    ASSERT_TRUE(iCartesianTrajectory->addWaypoint(x2));
+    ASSERT_TRUE(iCartesianTrajectory->configurePath(ICartesianTrajectory::LINE));
+    ASSERT_TRUE(iCartesianTrajectory->configureVelocityProfile(ICartesianTrajectory::RECTANGULAR));
+    ASSERT_TRUE(iCartesianTrajectory->create());
+
+    //-- Query duration according to a rectangular velocity profile
+    double duration;
+    ASSERT_TRUE(iCartesianTrajectory->getDuration(&duration));
+    ASSERT_NEAR(duration, 5.0, EPS);
+
+    //-- Use line
+    double movementTime = 2.0;
+    std::vector<double> position, velocity, acceleration;
+
+    ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
+    ASSERT_NEAR(position[0], x1[0] + 0.4, EPS);
+    ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
+    ASSERT_NEAR(velocity[0], MAX_VEL, EPS);
+    //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
+    //ASSERT_NEAR(acceleration[0], MAX_ACC, eps);
+
+    //-- Destroy line
+    ASSERT_TRUE(iCartesianTrajectory->destroy());
+}
+
+TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRectInitialTwist)
+{
+    //-- Create line trajectory
+    ASSERT_TRUE(iCartesianTrajectory->setDuration(10.0)); // Short duration means higher vel, beware of default limit
+    ASSERT_TRUE(iCartesianTrajectory->addWaypoint(x1, v1));
+    ASSERT_TRUE(iCartesianTrajectory->configurePath(ICartesianTrajectory::LINE));
+    ASSERT_TRUE(iCartesianTrajectory->configureVelocityProfile(ICartesianTrajectory::RECTANGULAR));
+    ASSERT_TRUE(iCartesianTrajectory->create());
+
+    //-- Query duration, should be the same as set before
+    double duration;
+    ASSERT_TRUE(iCartesianTrajectory->getDuration(&duration));
+    ASSERT_NEAR(duration, 10.0, EPS);
+
+    //-- Use line
+    double movementTime = 5.0;
+    std::vector<double> position, velocity, acceleration;
+
+    ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
+    ASSERT_NEAR(position[0], x1[0] + 0.5, EPS);
+    ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
+    ASSERT_NEAR(velocity[0], v1[0], EPS);
+    //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
+    //ASSERT_NEAR(acceleration[0], MAX_ACC, eps);
+
+    //-- Destroy line
+    ASSERT_TRUE(iCartesianTrajectory->destroy());
+}
+
+TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRectInitialTwistNoDuration)
+{
+    //-- Create line trajectory
+    ASSERT_TRUE(iCartesianTrajectory->addWaypoint(x1, v1));
+    ASSERT_TRUE(iCartesianTrajectory->configurePath(ICartesianTrajectory::LINE));
+    ASSERT_TRUE(iCartesianTrajectory->configureVelocityProfile(ICartesianTrajectory::RECTANGULAR));
+    ASSERT_TRUE(iCartesianTrajectory->create());
+
+    //-- Use line
+    double movementTime = 5.0;
+    std::vector<double> position, velocity, acceleration;
+
+    ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
+    ASSERT_NEAR(position[0], x1[0] + 0.5, EPS);
+    ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
+    ASSERT_NEAR(velocity[0], v1[0], EPS);
+    //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
+    //ASSERT_NEAR(acceleration[0], MAX_ACC, eps);
+
+    //-- Destroy line
+    ASSERT_TRUE(iCartesianTrajectory->destroy());
+}
+
+TEST_F(KdlTrajectoryTest, KdlTrajectoryLineRectInitialTwistNoDurationCapped)
+{
+    //-- Create line trajectory
+    ASSERT_TRUE(iCartesianTrajectory->addWaypoint(x1, v1_alt));
+    ASSERT_TRUE(iCartesianTrajectory->configurePath(ICartesianTrajectory::LINE));
+    ASSERT_TRUE(iCartesianTrajectory->configureVelocityProfile(ICartesianTrajectory::RECTANGULAR));
+    ASSERT_TRUE(iCartesianTrajectory->create());
+
+    //-- Use line
+    double movementTime = 5.0;
+    std::vector<double> position, velocity, acceleration;
+
+    ASSERT_TRUE(iCartesianTrajectory->getPosition(movementTime, position));
+    ASSERT_NEAR(position[0], x1[0] + 1.0, EPS);
+    ASSERT_TRUE(iCartesianTrajectory->getVelocity(movementTime, velocity));
+    ASSERT_NEAR(velocity[0], MAX_VEL, EPS);
+    //ASSERT_TRUE(iCartesianTrajectory->getAcceleration(movementTime, acceleration));
+    //ASSERT_NEAR(acceleration[0], MAX_ACC, eps);
+
+    //-- Destroy line
+    ASSERT_TRUE(iCartesianTrajectory->destroy());
 }
 
 }  // namespace roboticslab


### PR DESCRIPTION
Resolves #166. Notable changes:

* `KdlTrajectory`'s constructor now accepts motion parameter defaults (namely max velocity & acceleration).
* A few dreadful but necessary try-catch blocks for handling KDL exceptions.
* Race conditions are mitigated but not avoided in all cases. This actually demands some deeper insight I'm going to defer until #118 (currently blocked) is properly focused on. In other words, I'm intentionally introducing some technical debt that should be taken care of once we finally reach a stable codebase.
* Added support for rectangular velocity profiles, which provides a means to issue constant-velocity straight movements with `movv` while keeping track of a position reference (line path). As a result, it's no longer mandatory to provide a duration value to `KdlTrajectory` nor to add two waypoints prior to calling `create()`: users may choose to register two points along the path (as usual) or one point with an initial twist, which is closely related to how a linear, constant-velocity path with infinite duration is supposed to work. Trajectories that obey a trapezoidal velocity profile can be configured in the same manner, too. I called this single-point-initial-twist case (regardless of the duration) a "velocity driven path", see [relevant lines](https://github.com/roboticslab-uc3m/kinematics-dynamics/blob/eae5bd1187444c135814b540a6e695acd331a966/libraries/TrajectoryLib/KdlTrajectory.cpp#L203-L241).
* Enhanced unit tests.