### PR TITLE
Add encoder timestamps to ICartesianControl's stat() signature

### DIFF
--- a/bindings/kinematics_dynamics.i
+++ b/bindings/kinematics_dynamics.i
@@ -15,6 +15,10 @@
 %module "kinematics_dynamics"
 
 %include "std_vector.i"  /* Do not doubt about the importance of this line */
+%include "typemaps.i"
+
+%apply int *OUTPUT { int *state };
+%apply double *OUTPUT { double *timestamp };
 
 //%import "yarp.i"
 
@@ -29,17 +33,6 @@
 /* Parse the header file to generate wrappers */
 %include "ICartesianSolver.h"
 %include "ICartesianControl.h"
-
-%extend roboticslab::ICartesianControl
-{
-    int stat(std::vector<double> &x)
-    {
-        int buffer;
-        bool ok = self->stat(buffer, x);
-        if (!ok) return 0;
-        return buffer;
-    }
-}
 
 %{
 #include <yarp/dev/PolyDriver.h>

--- a/examples/python/exampleCartesianControlClient.py
+++ b/examples/python/exampleCartesianControlClient.py
@@ -24,8 +24,8 @@ cartesianControl = kinematics_dynamics.viewICartesianControl(dd)  # view the act
 
 print '> stat'
 x = yarp.DVector()
-stat = cartesianControl.stat(x)
-print '<',yarp.Vocab.decode(stat),'[%s]' % ', '.join(map(str, x))
+ret, state, ts = cartesianControl.stat(x)
+print '<', yarp.Vocab.decode(state), '[%s]' % ', '.join(map(str, x))
 
 xd = [0,0,0,0,0,0,0]
 

--- a/libraries/YarpPlugins/AmorCartesianControl/AmorCartesianControl.hpp
+++ b/libraries/YarpPlugins/AmorCartesianControl/AmorCartesianControl.hpp
@@ -52,7 +52,7 @@ public:
 
     // -- ICartesianControl declarations. Implementation in ICartesianControlImpl.cpp --
 
-    virtual bool stat(int &state, std::vector<double> &x);
+    virtual bool stat(std::vector<double> &x, int * state = 0);
 
     virtual bool inv(const std::vector<double> &xd, std::vector<double> &q);
 

--- a/libraries/YarpPlugins/AmorCartesianControl/AmorCartesianControl.hpp
+++ b/libraries/YarpPlugins/AmorCartesianControl/AmorCartesianControl.hpp
@@ -52,7 +52,7 @@ public:
 
     // -- ICartesianControl declarations. Implementation in ICartesianControlImpl.cpp --
 
-    virtual bool stat(std::vector<double> &x, int * state = 0);
+    virtual bool stat(std::vector<double> &x, int * state = 0, double * timestamp = 0);
 
     virtual bool inv(const std::vector<double> &xd, std::vector<double> &q);
 

--- a/libraries/YarpPlugins/AmorCartesianControl/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/AmorCartesianControl/ICartesianControlImpl.cpp
@@ -33,7 +33,10 @@ bool roboticslab::AmorCartesianControl::stat(std::vector<double> &x, int * state
 
     KinRepresentation::encodePose(x, x, KinRepresentation::CARTESIAN, KinRepresentation::RPY);
 
-    *state = currentState;
+    if (state != 0)
+    {
+        *state = currentState;
+    }
 
     return true;
 }

--- a/libraries/YarpPlugins/AmorCartesianControl/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/AmorCartesianControl/ICartesianControlImpl.cpp
@@ -11,7 +11,7 @@
 
 // ------------------- ICartesianControl Related ------------------------------------
 
-bool roboticslab::AmorCartesianControl::stat(std::vector<double> &x, int * state)
+bool roboticslab::AmorCartesianControl::stat(std::vector<double> &x, int * state, double * timestamp)
 {
     AMOR_VECTOR7 positions;
 
@@ -36,6 +36,11 @@ bool roboticslab::AmorCartesianControl::stat(std::vector<double> &x, int * state
     if (state != 0)
     {
         *state = currentState;
+    }
+
+    if (timestamp != 0)
+    {
+        *timestamp = yarp::os::Time::now();
     }
 
     return true;

--- a/libraries/YarpPlugins/AmorCartesianControl/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/AmorCartesianControl/ICartesianControlImpl.cpp
@@ -11,7 +11,7 @@
 
 // ------------------- ICartesianControl Related ------------------------------------
 
-bool roboticslab::AmorCartesianControl::stat(int &state, std::vector<double> &x)
+bool roboticslab::AmorCartesianControl::stat(std::vector<double> &x, int * state)
 {
     AMOR_VECTOR7 positions;
 
@@ -33,7 +33,7 @@ bool roboticslab::AmorCartesianControl::stat(int &state, std::vector<double> &x)
 
     KinRepresentation::encodePose(x, x, KinRepresentation::CARTESIAN, KinRepresentation::RPY);
 
-    state = currentState;
+    *state = currentState;
 
     return true;
 }
@@ -105,10 +105,9 @@ bool roboticslab::AmorCartesianControl::relj(const std::vector<double> &xd)
         return movj(xd);
     }
 
-    int state;
     std::vector<double> x;
 
-    if (!stat(state, x))
+    if (!stat(x))
     {
         CD_ERROR("stat failed.\n");
         return false;
@@ -199,10 +198,9 @@ bool roboticslab::AmorCartesianControl::movv(const std::vector<double> &xdotd)
         return false;
     }
 
-    int state;
     std::vector<double> xCurrent;
 
-    if (!stat(state, xCurrent))
+    if (!stat(xCurrent))
     {
         CD_ERROR("stat failed\n");
         return false;

--- a/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
@@ -139,7 +139,7 @@ public:
 
     // -- ICartesianControl declarations. Implementation in ICartesianControlImpl.cpp--
 
-    virtual bool stat(int &state, std::vector<double> &x);
+    virtual bool stat(std::vector<double> &x, int * state = 0);
 
     virtual bool inv(const std::vector<double> &xd, std::vector<double> &q);
 

--- a/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/BasicCartesianControl.hpp
@@ -7,6 +7,7 @@
 #include <yarp/dev/Drivers.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/PreciselyTimed.h>
 
 #include <iostream> // only windows
 #include <vector>
@@ -122,6 +123,7 @@ public:
                               iControlLimits(NULL),
                               iTorqueControl(NULL),
                               iControlMode(NULL),
+                              iPreciselyTimed(NULL),
                               referenceFrame(ICartesianSolver::BASE_FRAME),
                               gain(DEFAULT_GAIN),
                               maxJointVelocity(DEFAULT_QDOT_LIMIT),
@@ -139,7 +141,7 @@ public:
 
     // -- ICartesianControl declarations. Implementation in ICartesianControlImpl.cpp--
 
-    virtual bool stat(std::vector<double> &x, int * state = 0);
+    virtual bool stat(std::vector<double> &x, int * state = 0, double * timestamp = 0);
 
     virtual bool inv(const std::vector<double> &xd, std::vector<double> &q);
 
@@ -232,6 +234,7 @@ protected:
     yarp::dev::IControlLimits *iControlLimits;
     yarp::dev::ITorqueControl *iTorqueControl;
     yarp::dev::IControlMode2 *iControlMode;
+    yarp::dev::IPreciselyTimed *iPreciselyTimed;
 
     ICartesianSolver::reference_frame referenceFrame;
 

--- a/libraries/YarpPlugins/BasicCartesianControl/DeviceDriverImpl.cpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/DeviceDriverImpl.cpp
@@ -101,6 +101,11 @@ bool roboticslab::BasicCartesianControl::open(yarp::os::Searchable& config)
         return false;
     }
 
+    if (!robotDevice.view(iPreciselyTimed))
+    {
+        CD_WARNING("Could not view iPreciselyTimed in: %s. Using local timestamps.\n", robotStr.c_str());
+    }
+
     iEncoders->getAxes(&numRobotJoints);
     CD_INFO("numRobotJoints: %d.\n", numRobotJoints);
 

--- a/libraries/YarpPlugins/BasicCartesianControl/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/ICartesianControlImpl.cpp
@@ -31,7 +31,11 @@ bool roboticslab::BasicCartesianControl::stat(std::vector<double> &x, int * stat
         return false;
     }
 
-    *state = getCurrentState();
+    if (state != 0)
+    {
+        *state = getCurrentState();
+    }
+
     return true;
 }
 

--- a/libraries/YarpPlugins/BasicCartesianControl/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/ICartesianControlImpl.cpp
@@ -7,15 +7,26 @@
 #include <functional>
 #include <vector>
 
+#include <yarp/os/Time.h>
 #include <yarp/os/Vocab.h>
 
 #include <ColorDebug.h>
 
 #include "KdlTrajectory.hpp"
 
+// -----------------------------------------------------------------------------
+
+namespace
+{
+    inline double getTimestamp(yarp::dev::IPreciselyTimed * iPreciselyTimed)
+    {
+        return iPreciselyTimed != NULL ? iPreciselyTimed->getLastInputStamp().getTime() : yarp::os::Time::now();
+    }
+}
+
 // ------------------- ICartesianControl Related ------------------------------------
 
-bool roboticslab::BasicCartesianControl::stat(std::vector<double> &x, int * state)
+bool roboticslab::BasicCartesianControl::stat(std::vector<double> &x, int * state, double * timestamp)
 {
     std::vector<double> currentQ(numRobotJoints);
 
@@ -23,6 +34,11 @@ bool roboticslab::BasicCartesianControl::stat(std::vector<double> &x, int * stat
     {
         CD_ERROR("getEncoders failed.\n");
         return false;
+    }
+
+    if (timestamp != NULL)
+    {
+        *timestamp = getTimestamp(iPreciselyTimed);
     }
 
     if (!iCartesianSolver->fwdKin(currentQ, x))

--- a/libraries/YarpPlugins/BasicCartesianControl/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/BasicCartesianControl/ICartesianControlImpl.cpp
@@ -15,7 +15,7 @@
 
 // ------------------- ICartesianControl Related ------------------------------------
 
-bool roboticslab::BasicCartesianControl::stat(int &state, std::vector<double> &x)
+bool roboticslab::BasicCartesianControl::stat(std::vector<double> &x, int * state)
 {
     std::vector<double> currentQ(numRobotJoints);
 
@@ -31,7 +31,7 @@ bool roboticslab::BasicCartesianControl::stat(int &state, std::vector<double> &x
         return false;
     }
 
-    state = getCurrentState();
+    *state = getCurrentState();
     return true;
 }
 
@@ -152,10 +152,9 @@ bool roboticslab::BasicCartesianControl::relj(const std::vector<double> &xd)
         return movj(xd);
     }
 
-    int state;
     std::vector<double> x;
 
-    if (!stat(state, x))
+    if (!stat(x))
     {
         CD_ERROR("stat failed.\n");
         return false;

--- a/libraries/YarpPlugins/CartesianControlClient/CartesianControlClient.hpp
+++ b/libraries/YarpPlugins/CartesianControlClient/CartesianControlClient.hpp
@@ -40,12 +40,13 @@ public:
 
     FkStreamResponder();
     void onRead(yarp::os::Bottle& b);
-    bool getLastStatData(std::vector<double> &x, int *state, double timeout);
+    bool getLastStatData(std::vector<double> &x, int *state, double * timestamp, double timeout);
 
 protected:
 
     double localArrivalTime;
     int state;
+    double timestamp;
     std::vector<double> x;
     mutable yarp::os::Semaphore mutex;
 };
@@ -60,7 +61,7 @@ public:
 
     // -- ICartesianControl declarations. Implementation in ICartesianControlImpl.cpp--
 
-    virtual bool stat(std::vector<double> &x, int * state = 0);
+    virtual bool stat(std::vector<double> &x, int * state = 0, double * timestamp = 0);
 
     virtual bool inv(const std::vector<double> &xd, std::vector<double> &q);
 

--- a/libraries/YarpPlugins/CartesianControlClient/CartesianControlClient.hpp
+++ b/libraries/YarpPlugins/CartesianControlClient/CartesianControlClient.hpp
@@ -65,7 +65,7 @@ public:
 
     // -- ICartesianControl declarations. Implementation in ICartesianControlImpl.cpp--
 
-    virtual bool stat(int &state, std::vector<double> &x);
+    virtual bool stat(std::vector<double> &x, int * state = 0);
 
     virtual bool inv(const std::vector<double> &xd, std::vector<double> &q);
 

--- a/libraries/YarpPlugins/CartesianControlClient/CartesianControlClient.hpp
+++ b/libraries/YarpPlugins/CartesianControlClient/CartesianControlClient.hpp
@@ -38,21 +38,16 @@ class FkStreamResponder : public yarp::os::TypedReaderCallback<yarp::os::Bottle>
 {
 public:
 
-    FkStreamResponder() : now(0.0),
-                          state(0)
-    {}
-
+    FkStreamResponder();
     void onRead(yarp::os::Bottle& b);
-
-    double getLastStatData(int *state, std::vector<double> &x);
+    bool getLastStatData(std::vector<double> &x, int *state, double timeout);
 
 protected:
 
-    double now;
+    double localArrivalTime;
     int state;
     std::vector<double> x;
-
-    yarp::os::Semaphore mutex;
+    mutable yarp::os::Semaphore mutex;
 };
 
 /**

--- a/libraries/YarpPlugins/CartesianControlClient/FkStreamResponder.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/FkStreamResponder.cpp
@@ -4,13 +4,20 @@
 
 #include <yarp/os/Time.h>
 
-// ------------------- DeviceDriver Related ------------------------------------
+// -----------------------------------------------------------------------------
+
+roboticslab::FkStreamResponder::FkStreamResponder()
+    : localArrivalTime(0.0),
+      state(0)
+{}
+
+// -----------------------------------------------------------------------------
 
 void roboticslab::FkStreamResponder::onRead(yarp::os::Bottle & b)
 {
     mutex.wait();
 
-    now = yarp::os::Time::now();
+    localArrivalTime = yarp::os::Time::now();
     state = b.get(0).asVocab();
     x.resize(b.size() - 1);
 
@@ -24,19 +31,20 @@ void roboticslab::FkStreamResponder::onRead(yarp::os::Bottle & b)
 
 // -----------------------------------------------------------------------------
 
-double roboticslab::FkStreamResponder::getLastStatData(int *state, std::vector<double> &x)
+bool roboticslab::FkStreamResponder::getLastStatData(std::vector<double> &x, int *state, const double timeout)
 {
+    double now = yarp::os::Time::now();
     double localArrivalTime;
 
     mutex.wait();
 
+    localArrivalTime = this->localArrivalTime;
     *state = this->state;
     x = this->x;
-    localArrivalTime = now;
 
     mutex.post();
 
-    return localArrivalTime;
+    return now - localArrivalTime <= timeout;
 }
 
 // -----------------------------------------------------------------------------

--- a/libraries/YarpPlugins/CartesianControlClient/FkStreamResponder.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/FkStreamResponder.cpp
@@ -39,8 +39,12 @@ bool roboticslab::FkStreamResponder::getLastStatData(std::vector<double> &x, int
     mutex.wait();
 
     localArrivalTime = this->localArrivalTime;
-    *state = this->state;
     x = this->x;
+
+    if (state != 0)
+    {
+        *state = this->state;
+    }
 
     mutex.post();
 

--- a/libraries/YarpPlugins/CartesianControlClient/FkStreamResponder.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/FkStreamResponder.cpp
@@ -4,34 +4,39 @@
 
 #include <yarp/os/Time.h>
 
+using namespace roboticslab;
+
 // -----------------------------------------------------------------------------
 
-roboticslab::FkStreamResponder::FkStreamResponder()
+FkStreamResponder::FkStreamResponder()
     : localArrivalTime(0.0),
-      state(0)
+      state(0),
+      timestamp(0.0)
 {}
 
 // -----------------------------------------------------------------------------
 
-void roboticslab::FkStreamResponder::onRead(yarp::os::Bottle & b)
+void FkStreamResponder::onRead(yarp::os::Bottle & b)
 {
     mutex.wait();
 
     localArrivalTime = yarp::os::Time::now();
     state = b.get(0).asVocab();
-    x.resize(b.size() - 1);
+    x.resize(b.size() - 2);
 
     for (size_t i = 0; i < x.size(); i++)
     {
         x[i] = b.get(i + 1).asDouble();
     }
 
+    timestamp = b.get(b.size() - 1).asDouble();
+
     mutex.post();
 }
 
 // -----------------------------------------------------------------------------
 
-bool roboticslab::FkStreamResponder::getLastStatData(std::vector<double> &x, int *state, const double timeout)
+bool FkStreamResponder::getLastStatData(std::vector<double> &x, int *state, double *timestamp, const double timeout)
 {
     double now = yarp::os::Time::now();
     double localArrivalTime;
@@ -44,6 +49,11 @@ bool roboticslab::FkStreamResponder::getLastStatData(std::vector<double> &x, int
     if (state != 0)
     {
         *state = this->state;
+    }
+
+    if (timestamp != 0)
+    {
+        *timestamp = this->timestamp;
     }
 
     mutex.post();

--- a/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
@@ -140,14 +140,14 @@ bool roboticslab::CartesianControlClient::stat(std::vector<double> &x, int * sta
 {
     if (fkStreamEnabled)
     {
-        double localArrivalTime = fkStreamResponder.getLastStatData(state, x);
-
-        if (yarp::os::Time::now() - localArrivalTime <= fkStreamTimeoutSecs)
+        if (!fkStreamResponder.getLastStatData(x, state, fkStreamTimeoutSecs))
+        {
+            CD_WARNING("FK stream timeout, falling back to RPC request.\n");
+        }
+        else
         {
             return true;
         }
-
-        CD_WARNING("FK stream timeout, sending RPC request.\n");
     }
 
     yarp::os::Bottle cmd, response;

--- a/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
@@ -136,11 +136,11 @@ void roboticslab::CartesianControlClient::handleStreamingBiConsumerCmd(int vocab
 
 // -----------------------------------------------------------------------------
 
-bool roboticslab::CartesianControlClient::stat(std::vector<double> &x, int * state)
+bool roboticslab::CartesianControlClient::stat(std::vector<double> &x, int * state, double * timestamp)
 {
     if (fkStreamEnabled)
     {
-        if (!fkStreamResponder.getLastStatData(x, state, fkStreamTimeoutSecs))
+        if (!fkStreamResponder.getLastStatData(x, state, timestamp, fkStreamTimeoutSecs))
         {
             CD_WARNING("FK stream timeout, falling back to RPC request.\n");
         }
@@ -166,11 +166,16 @@ bool roboticslab::CartesianControlClient::stat(std::vector<double> &x, int * sta
         *state = response.get(0).asVocab();
     }
 
-    x.resize(response.size() - 1);
+    x.resize(response.size() - 2);
 
     for (size_t i = 0; i < x.size(); i++)
     {
         x[i] = response.get(i + 1).asDouble();
+    }
+
+    if (timestamp != 0)
+    {
+        *timestamp = response.get(response.size() - 1).asDouble();
     }
 
     return true;

--- a/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
@@ -136,11 +136,11 @@ void roboticslab::CartesianControlClient::handleStreamingBiConsumerCmd(int vocab
 
 // -----------------------------------------------------------------------------
 
-bool roboticslab::CartesianControlClient::stat(int &state, std::vector<double> &x)
+bool roboticslab::CartesianControlClient::stat(std::vector<double> &x, int * state)
 {
     if (fkStreamEnabled)
     {
-        double localArrivalTime = fkStreamResponder.getLastStatData(&state, x);
+        double localArrivalTime = fkStreamResponder.getLastStatData(state, x);
 
         if (yarp::os::Time::now() - localArrivalTime <= fkStreamTimeoutSecs)
         {
@@ -161,7 +161,7 @@ bool roboticslab::CartesianControlClient::stat(int &state, std::vector<double> &
         return false;
     }
 
-    state = response.get(0).asVocab();
+    *state = response.get(0).asVocab();
     x.resize(response.size() - 1);
 
     for (size_t i = 0; i < x.size(); i++)

--- a/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlClient/ICartesianControlImpl.cpp
@@ -161,7 +161,11 @@ bool roboticslab::CartesianControlClient::stat(std::vector<double> &x, int * sta
         return false;
     }
 
-    *state = response.get(0).asVocab();
+    if (state != 0)
+    {
+        *state = response.get(0).asVocab();
+    }
+
     x.resize(response.size() - 1);
 
     for (size_t i = 0; i < x.size(); i++)

--- a/libraries/YarpPlugins/CartesianControlServer/RateThreadImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/RateThreadImpl.cpp
@@ -11,7 +11,7 @@ void roboticslab::CartesianControlServer::run()
     std::vector<double> x;
     int state;
 
-    if (!iCartesianControl->stat(state, x))
+    if (!iCartesianControl->stat(x, &state))
     {
         return;
     }

--- a/libraries/YarpPlugins/CartesianControlServer/RateThreadImpl.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/RateThreadImpl.cpp
@@ -10,8 +10,9 @@ void roboticslab::CartesianControlServer::run()
 {
     std::vector<double> x;
     int state;
+    double timestamp;
 
-    if (!iCartesianControl->stat(x, &state))
+    if (!iCartesianControl->stat(x, &state, &timestamp))
     {
         return;
     }
@@ -24,6 +25,8 @@ void roboticslab::CartesianControlServer::run()
     {
         out.addDouble(x[i]);
     }
+
+    out.addDouble(timestamp);
 
     fkOutPort.write();
 

--- a/libraries/YarpPlugins/CartesianControlServer/RpcResponder.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/RpcResponder.cpp
@@ -195,7 +195,7 @@ bool roboticslab::RpcResponder::handleStatMsg(const yarp::os::Bottle& in, yarp::
     std::vector<double> x;
     int state;
 
-    if (iCartesianControl->stat(state, x))
+    if (iCartesianControl->stat(x, &state))
     {
         if (!transformOutgoingData(x))
         {

--- a/libraries/YarpPlugins/CartesianControlServer/RpcResponder.cpp
+++ b/libraries/YarpPlugins/CartesianControlServer/RpcResponder.cpp
@@ -89,7 +89,7 @@ void roboticslab::RpcResponder::makeUsage()
     std::stringstream ss;
 
     ss << "[" << yarp::os::Vocab::decode(VOCAB_CC_STAT) << "]";
-    addUsage(ss.str().c_str(), "get current position in cartesian space");
+    addUsage(ss.str().c_str(), "get controller state, current position in cartesian space and encoder acquisition timestamp");
     ss.str("");
 
     ss << "[" << yarp::os::Vocab::decode(VOCAB_CC_INV) << "] coord1 coord2 ...";
@@ -194,8 +194,9 @@ bool roboticslab::RpcResponder::handleStatMsg(const yarp::os::Bottle& in, yarp::
 {
     std::vector<double> x;
     int state;
+    double timestamp;
 
-    if (iCartesianControl->stat(x, &state))
+    if (iCartesianControl->stat(x, &state, &timestamp))
     {
         if (!transformOutgoingData(x))
         {
@@ -209,6 +210,8 @@ bool roboticslab::RpcResponder::handleStatMsg(const yarp::os::Bottle& in, yarp::
         {
             out.addDouble(x[i]);
         }
+
+        out.addDouble(timestamp);
 
         return true;
     }

--- a/libraries/YarpPlugins/ICartesianControl.h
+++ b/libraries/YarpPlugins/ICartesianControl.h
@@ -145,14 +145,14 @@ class ICartesianControl
          *
          * Inform on control state, get robot position and perform forward kinematics.
          *
-         * @param state Identifier for a cartesian control vocab.
          * @param x 6-element vector describing current position in cartesian space; first
          * three elements denote translation (meters), last three denote rotation in scaled
          * axis-angle representation (radians).
+         * @param state Identifier for a cartesian control vocab.
          *
          * @return true on success, false otherwise
          */
-        virtual bool stat(int &state, std::vector<double> &x) = 0;
+        virtual bool stat(std::vector<double> &x, int * state = 0) = 0;
 
         /**
          * @brief Inverse kinematics

--- a/libraries/YarpPlugins/ICartesianControl.h
+++ b/libraries/YarpPlugins/ICartesianControl.h
@@ -8,6 +8,8 @@
 
 #include "ICartesianSolver.h"
 
+#include <ColorDebug.h> // FIXME: stat() deprecation
+
 #ifndef SWIG_PREPROCESSOR_SHOULD_SKIP_THIS
 #define ROBOTICSLAB_VOCAB(a,b,c,d) ((((int)(d))<<24)+(((int)(c))<<16)+(((int)(b))<<8)+((int)(a)))
 #endif // SWIG_PREPROCESSOR_SHOULD_SKIP_THIS
@@ -154,6 +156,15 @@ class ICartesianControl
          * @return true on success, false otherwise
          */
         virtual bool stat(std::vector<double> &x, int * state = 0, double * timestamp = 0) = 0;
+
+#ifndef SWIG_PREPROCESSOR_SHOULD_SKIP_THIS
+        __attribute__((__deprecated__))
+        virtual bool stat(int & state, std::vector<double> & x)
+        {
+            CD_WARNING("Deprecated signature.\n");
+            return stat(x, &state);
+        }
+#endif
 
         /**
          * @brief Inverse kinematics

--- a/libraries/YarpPlugins/ICartesianControl.h
+++ b/libraries/YarpPlugins/ICartesianControl.h
@@ -149,10 +149,11 @@ class ICartesianControl
          * three elements denote translation (meters), last three denote rotation in scaled
          * axis-angle representation (radians).
          * @param state Identifier for a cartesian control vocab.
+         * @param timestamp Remote encoder acquisition time.
          *
          * @return true on success, false otherwise
          */
-        virtual bool stat(std::vector<double> &x, int * state = 0) = 0;
+        virtual bool stat(std::vector<double> &x, int * state = 0, double * timestamp = 0) = 0;
 
         /**
          * @brief Inverse kinematics

--- a/programs/keyboardController/KeyboardController.cpp
+++ b/programs/keyboardController/KeyboardController.cpp
@@ -599,10 +599,8 @@ void roboticslab::KeyboardController::printCartesianPositions()
         return;
     }
 
-    int state;
     std::vector<double> x;
-
-    iCartesianControl->stat(state, x);
+    iCartesianControl->stat(x);
     KinRepresentation::decodePose(x, x, KinRepresentation::CARTESIAN, orient, KinRepresentation::DEGREES);
 
     std::cout << "Current cartesian positions [meters, degrees (" << angleRepr << ")]: " << std::endl;

--- a/programs/keyboardController/LinearTrajectoryThread.cpp
+++ b/programs/keyboardController/LinearTrajectoryThread.cpp
@@ -64,10 +64,9 @@ bool LinearTrajectoryThread::configure(const std::vector<double> & vels)
         return true;
     }
 
-    int state;
     std::vector<double> x;
 
-    if (!iCartesianControl->stat(state, x))
+    if (!iCartesianControl->stat(x))
     {
         CD_ERROR("stat failed.\n");
         return false;

--- a/programs/streamingDeviceController/LeapMotionSensorDevice.cpp
+++ b/programs/streamingDeviceController/LeapMotionSensorDevice.cpp
@@ -63,10 +63,9 @@ bool roboticslab::LeapMotionSensorDevice::initialize(bool usingStreamingPreset)
         return false;
     }
 
-    int state;
     std::vector<double> x;
 
-    if (!iCartesianControl->stat(state, initialOffset))
+    if (!iCartesianControl->stat(initialOffset))
     {
         CD_WARNING("stat failed.\n");
         return false;

--- a/tests/testBasicCartesianControl.cpp
+++ b/tests/testBasicCartesianControl.cpp
@@ -51,7 +51,7 @@ TEST_F( BasicCartesianControlTest, BasicCartesianControlStat)
 {
     std::vector<double> x;
     int state;
-    iCartesianControl->stat(state,x);
+    iCartesianControl->stat(x,&state);
     ASSERT_EQ(state,VOCAB_CC_NOT_CONTROLLING);
     ASSERT_NEAR(x[0], 1, 1e-9);
     ASSERT_NEAR(x[1], 0, 1e-9);
@@ -89,7 +89,6 @@ TEST_F( BasicCartesianControlTest, BasicCartesianControlInv2)
 TEST_F( BasicCartesianControlTest, BasicCartesianControlTool)
 {
     std::vector<double> x(6),xToolA,xToolB,xNoTool;
-    int state;
 
     // add tool ('A')
     x[0] = 0;  // x
@@ -99,7 +98,7 @@ TEST_F( BasicCartesianControlTest, BasicCartesianControlTool)
     x[4] = 0;  // o(y)
     x[5] = 0;  // o(z)
     ASSERT_TRUE(iCartesianControl->tool(x));
-    ASSERT_TRUE(iCartesianControl->stat(state, xToolA));
+    ASSERT_TRUE(iCartesianControl->stat(xToolA));
     ASSERT_NEAR(xToolA[0], 1, 1e-9);
     ASSERT_NEAR(xToolA[1], 0, 1e-9);
     ASSERT_NEAR(xToolA[2], 1, 1e-9);
@@ -112,7 +111,7 @@ TEST_F( BasicCartesianControlTest, BasicCartesianControlTool)
     x[0] = 1;
     x[4] = M_PI / 4;
     ASSERT_TRUE(iCartesianControl->tool(x));
-    ASSERT_TRUE(iCartesianControl->stat(state, xToolB));
+    ASSERT_TRUE(iCartesianControl->stat(xToolB));
     ASSERT_NEAR(xToolB[0], 2, 1e-9);
     ASSERT_NEAR(xToolB[1], 0, 1e-9);
     ASSERT_NEAR(xToolB[2], 0, 1e-9);
@@ -123,7 +122,7 @@ TEST_F( BasicCartesianControlTest, BasicCartesianControlTool)
     // remove tool
     std::fill(x.begin(), x.end(), 0);
     ASSERT_TRUE(iCartesianControl->tool(x));
-    ASSERT_TRUE(iCartesianControl->stat(state, xNoTool));
+    ASSERT_TRUE(iCartesianControl->stat(xNoTool));
     ASSERT_NEAR(xNoTool[0], 1, 1e-9);
     ASSERT_NEAR(xNoTool[1], 0, 1e-9);
     ASSERT_NEAR(xNoTool[2], 0, 1e-9);


### PR DESCRIPTION
Closes https://github.com/roboticslab-uc3m/kinematics-dynamics/issues/175. The signature of `ICartesianControl::stat` has been changed in order to include the instant in which joint data acquisition has been performed:

```c++
bool stat(std::vector<double> &x, int * state = 0, double * timestamp = 0);
```

Now, the `state` parameter is optional, therefore consumers don't need to declare an unused variable anymore, just call `iCartesianControl->stat(x)` in case they don't care about the current controller state (nor the encoder timestamp).

The BCC implementation relies on the availability of a `yarp::dev::IPreciselyTimed` implementation on the remote robot. If that's not the case, BCC generates a timestamp on the fly. This could be turned into an error on BCC's initialization.

Python bindings have been updated, see example: `ret, state, timestamp = iCartesianControl->stat(x)`. I believe that the glue file `.i` could be improved upon, but this is beyond my SWIG skills.